### PR TITLE
Missing nullcheck in gd_topal.c

### DIFF
--- a/src/gd_topal.c
+++ b/src/gd_topal.c
@@ -1519,11 +1519,11 @@ static int gdImageTrueColorToPaletteBody (gdImagePtr oim, int dither, int colors
 			gdImageDestroy(nim);
 		}
 		nim = gdImageNeuQuant(oim, colorsWanted, oim->paletteQuantizationSpeed ? oim->paletteQuantizationSpeed : 2);
-		if (!nim) {
-			return FALSE;
-		}
 		if (cimP) {
 			*cimP = nim;
+		} 
+		if (!nim) {
+			return FALSE;
 		} else {
 			gdImageCopy(oim, nim, 0, 0, 0, 0, oim->sx, oim->sy);
 			gdImageDestroy(nim);

--- a/src/gd_topal.c
+++ b/src/gd_topal.c
@@ -1519,6 +1519,9 @@ static int gdImageTrueColorToPaletteBody (gdImagePtr oim, int dither, int colors
 			gdImageDestroy(nim);
 		}
 		nim = gdImageNeuQuant(oim, colorsWanted, oim->paletteQuantizationSpeed ? oim->paletteQuantizationSpeed : 2);
+		if (!nim) {
+			return FALSE;
+		}
 		if (cimP) {
 			*cimP = nim;
 		} else {


### PR DESCRIPTION
Issue : In API  [ gdImageTrueColorToPaletteBody()]  gdImageNeuQuant() may possibly return NULL. 

nim can hold NULL value.

Should be NULL checked.