### PR TITLE
Remove Deadcode in gd_nnquant.c

### DIFF
--- a/src/gd_nnquant.c
+++ b/src/gd_nnquant.c
@@ -463,7 +463,7 @@ int verbose;
 	radius = initradius;
 
 	rad = radius >> radiusbiasshift;
-	if (rad <= 1) rad = 0;
+	
 	for (i=0; i<rad; i++)
 		nnq->radpower[i] = alpha*(((rad*rad - i*i)*radbias)/(rad*rad));
 


### PR DESCRIPTION
File gd_nnquant.c : 
 
         #define initrad         (MAXNETSIZE>>3)                      // 256 >>3 = 32
         #define radiusbiasshift 6                               
         #define radiusbias      (((int) 1)<<radiusbiasshift)          // 1 << 6 = 64
         #define initradius      (initrad*radiusbias)                      // 32 * 64 = 2048 (fixed value) 

In API learn() 

        radius = initradius;                                      // initradius = 2048 
        rad = radius >> radiusbiasshift;                  // radiusbiasshift =6 which outputs radius >> 6 =32 
        if (rad <= 1) rad = 0;                                   // rad <=1 always false. Code block has no impact. 
      
Code block can be removed.  [ if (rad <= 1) rad = 0; ] 
