### PR TITLE
gdImageScaleTwoPass memory leak fix

### DIFF
--- a/src/gd_interpolation.c
+++ b/src/gd_interpolation.c
@@ -1087,7 +1087,7 @@ gdImageScaleTwoPass(const gdImagePtr src, const unsigned int new_width,
     }/* if */
 
     if (src != tmp_im) {
-        gdFree(tmp_im);
+        gdImageDestroy(tmp_im);
     }/* if */
 
 	return dst;


### PR DESCRIPTION
Fixing memory leak in gdImageScaleTwoPass, as reported by @cmb69 and confirmed by @vapier.
This bug actually bit me in production and I'm very thankful that it was reported with an easy fix.