### PR TITLE
Free of NULL, Not needed.

### DIFF
--- a/src/gd_png.c
+++ b/src/gd_png.c
@@ -293,8 +293,6 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromPngCtx (gdIOCtx * infile)
 	if (setjmp(jbw.jmpbuf)) {
 		gd_error("gd-png error: setjmp returns error condition 2\n");
 		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
-		gdFree(image_data);
-		gdFree(row_pointers);
 		if (im) {
 			gdImageDestroy(im);
 		}
@@ -407,8 +405,6 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromPngCtx (gdIOCtx * infile)
 	default:
 		gd_error("gd-png color_type is unknown: %d\n", color_type);
 		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
-		gdFree(image_data);
-		gdFree(row_pointers);
 		if (im) {
 			gdImageDestroy(im);
 		}


### PR DESCRIPTION
In file gd_png.c : 
line 296 and 410  image_data is NULL and by passing as 1st parameter to function 'gdFree' is freed. 
line 297 and 411  row_pointers is NULL and by passing as 1st parameter to function 'gdFree' is freed. 

However, this free does not have any impact and free(NULL) is treated as a no-op. So gdfree not needed. 

Thanks