### PR TITLE
NULL check before Dereferencing null return value

### DIFF
--- a/src/circletexttest.c
+++ b/src/circletexttest.c
@@ -26,12 +26,24 @@ int main(void)
 	in = fopen("eleanor.jpg", "rb");
 	if(!in) {
 		im = gdImageCreateTrueColor(300, 300);
+		if(!im) {
+			fprintf(stderr, "gdImageCreateTrueColor failed \n");
+			return 1;
+		}
 	} else {
 		im = gdImageCreateFromJpeg(in);
 		fclose(in);
+		if(!im) {
+			fprintf(stderr, "gdImageCreateFromJpeg failed \n");
+			return 1;
+		}
 	}
 #else
 	im = gdImageCreateTrueColor(300, 300);
+	if(!im) {
+		fprintf(stderr, "gdImageCreateTrueColor failed \n");
+		return 1;
+	}
 #endif /* HAVE_LIBJPEG */
 	if(gdImageSX(im) < gdImageSY(im)) {
 		radius = gdImageSX(im) / 2;

--- a/src/circletexttest.c
+++ b/src/circletexttest.c
@@ -26,25 +26,17 @@ int main(void)
 	in = fopen("eleanor.jpg", "rb");
 	if(!in) {
 		im = gdImageCreateTrueColor(300, 300);
-		if(!im) {
-			fprintf(stderr, "gdImageCreateTrueColor failed \n");
-			return 1;
-		}
 	} else {
 		im = gdImageCreateFromJpeg(in);
 		fclose(in);
-		if(!im) {
-			fprintf(stderr, "gdImageCreateFromJpeg failed \n");
-			return 1;
-		}
 	}
 #else
 	im = gdImageCreateTrueColor(300, 300);
+#endif /* HAVE_LIBJPEG */
 	if(!im) {
 		fprintf(stderr, "gdImageCreateTrueColor failed \n");
 		return 1;
 	}
-#endif /* HAVE_LIBJPEG */
 	if(gdImageSX(im) < gdImageSY(im)) {
 		radius = gdImageSX(im) / 2;
 	} else {


### PR DESCRIPTION
In circletexttest.c, return value of gdImageCreateFromJpeg() and gdImageCreateTrueColor() must be checked before Dereferncing.