### PR TITLE
Fix and extend Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,45 @@
 language: cpp
 
-env:
+#env:
   #global:
   #  # COVERITY_SCAN_TOKEN
   #  - secure: "HK0Ey4+9OsxcWl0FwNzwbkEkvHMD7DM27x3NWeY8Lo2NmU2ZBB72Q3TWIBtk6YpeY5glsBTUQob17H+ISQR2xHqL5GaGf1hWk9x7iBAA4XRb4RUgCnzEE6vPmUGcxcjx0AIjtbnFKShoEOKbN/O2ms1zqz8rgUTNiAQWFgJKCW0="
-  - tbs_arch=x86
-  - tbs_arch=x64
 
-os:
-  - linux
-  - osx
+matrix:
+    include:
+        - os: linux
+          compiler: gcc
+          env: BUILD_TYPE=normal tbs_arch=x86
+        - os: linux
+          compiler: gcc
+          env: BUILD_TYPE=normal tbs_arch=x64
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=normal tbs_arch=x86
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=normal tbs_arch=x64
+        - os: osx
+          compiler: gcc
+          env: BUILD_TYPE=normal tbs_arch=x86
+        - os: osx
+          compiler: gcc
+          env: BUILD_TYPE=normal tbs_arch=x64
+        - os: osx
+          compiler: clang
+          env: BUILD_TYPE=normal tbs_arch=x86
+        - os: osx
+          compiler: clang
+          env: BUILD_TYPE=normal tbs_arch=x64
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=ubsan tbs_arch=x64
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=asan tbs_arch=x64
+        #- os: linux
+        #  compiler: gcc
+        #  env: BUILD_TYPE=coverage tbs_arch=x64
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" = "linux" ];
@@ -38,6 +68,8 @@ before_install:
         sudo apt-get -y install gcc-multilib;
         sudo apt-get -y install g++-multilib;
       fi;
+      pip install --user 'requests[security]';
+      pip install --user cpp-coveralls;
     fi
   
   - if [ "$TRAVIS_OS_NAME" = "osx" ];
@@ -49,6 +81,23 @@ before_script:
   - if [ "$TRAVIS_OS_NAME" = "linux" ];
     then
       autoreconf -fi;
+    fi
+  - if [ "$BUILD_TYPE" = "coverage" ];
+    then
+      export CFLAGS="-fprofile-arcs -ftest-coverage";
+      export LDFLAGS="-fprofile-arcs -ftest-coverage";
+    fi
+  - if [ "$BUILD_TYPE" = "asan" ];
+    then
+      export CFLAGS=-fsanitize=address;
+      export LDFLAGS=-fsanitize=address;
+    fi
+  # Use all the parts of UBSAN except shift checks (-fsanitize=shift, for gd_io.c:139) and index-out-of-bounds (-fsanitize=bounds, for gd_gif_in.c:459)
+  - if [ "$BUILD_TYPE" = "ubsan" ];
+    then
+      export UBSAN_FLAGS="-fsanitize=alignment -fsanitize=bool -fsanitize=enum -fsanitize=float-cast-overflow -fsanitize=float-divide-by-zero -fsanitize=function -fsanitize=integer-divide-by-zero -fsanitize=null -fsanitize=object-size -fsanitize=return -fsanitize=signed-integer-overflow -fsanitize=unreachable -fsanitize=unsigned-integer-overflow";
+      export CFLAGS=$UBSAN_FLAGS;
+      export LDFLAGS=$UBSAN_FLAGS;
     fi
 
 script:
@@ -62,6 +111,10 @@ script:
     then
       ./thumbs.sh make;
       ./thumbs.sh check;
+    fi
+  - if [ "$BUILD_TYPE" = "coverage" ];
+    then
+      cpp-coveralls --exclude tests --gcov-options '\-lp';
     fi
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ script:
     then
       ./configure --with-tiff=/usr --libdir=/usr/lib/$(dpkg-architecture -qDEB_TARGET_MULTIARCH);
       make;
-      make check || true;
+      make check;
     fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ];
     then

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,12 @@ matrix:
         - os: linux
           compiler: clang
           env: BUILD_TYPE=asan tbs_arch=x64
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=lsan tbs_arch=x64
+        - os: linux
+          compiler: clang
+          env: BUILD_TYPE=msan tbs_arch=x64
         #- os: linux
         #  compiler: gcc
         #  env: BUILD_TYPE=coverage tbs_arch=x64
@@ -91,6 +97,16 @@ before_script:
     then
       export CFLAGS=-fsanitize=address;
       export LDFLAGS=-fsanitize=address;
+    fi
+  - if [ "$BUILD_TYPE" = "lsan" ];
+    then
+      export CFLAGS=-fsanitize=leak;
+      export LDFLAGS=-fsanitize=leak;
+    fi
+  - if [ "$BUILD_TYPE" = "msan" ];
+    then
+      export CFLAGS=-fsanitize=memory;
+      export LDFLAGS=-fsanitize=memory;
     fi
   # Use all the parts of UBSAN except shift checks (-fsanitize=shift, for gd_io.c:139) and index-out-of-bounds (-fsanitize=bounds, for gd_gif_in.c:459)
   - if [ "$BUILD_TYPE" = "ubsan" ];

--- a/src/gd_tiff.c
+++ b/src/gd_tiff.c
@@ -972,6 +972,7 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromTiffCtx(gdIOCtx *infile)
 	}
 error:
 	TIFFClose(tif);
+	gdFree(th);
 	return im;
 }
 

--- a/tests/gdimagefill/bug00002_2.c
+++ b/tests/gdimagefill/bug00002_2.c
@@ -45,6 +45,7 @@ int main()
 
 	/* Destroy it */
 	gdImageDestroy(im);
+	gdImageDestroy(tile);
 	return error;
 }
 

--- a/tests/gdimagefill/bug00002_3.c
+++ b/tests/gdimagefill/bug00002_3.c
@@ -51,6 +51,7 @@ int main()
 
 	/* Destroy it */
 	gdImageDestroy(im);
+	gdImageDestroy(tile);
 	return error;
 }
 

--- a/tests/gdimagefilter/gdCopyBlurred.c
+++ b/tests/gdimagefilter/gdCopyBlurred.c
@@ -110,6 +110,9 @@ void do_test()
     blurblank(im, 4, 0.0);
     blurblank(im, 8, 0.0);
     blurblank(im, 16, 0.0);
+
+    gdImageDestroy(im);
+    gdImageDestroy(imref);
 }/* do_test*/
 
 /* Ensure that RGB values are equal, then return r (which is therefore
@@ -185,6 +188,7 @@ void do_crosstest()
     gdTestAssert(getwhite(blurred, 1, LY + 1) <  getwhite(blurred, 1, LY + 3));
     gdTestAssert(getwhite(blurred, 1, LY + 3) <  getwhite(blurred, 1, HEIGHT-1));
 	gdImageDestroy(blurred);
+	gdImageDestroy(im);
 }/* do_crosstest*/
 
 

--- a/tests/gdimageline/gdimageline_aa_outofrange.c
+++ b/tests/gdimageline/gdimageline_aa_outofrange.c
@@ -15,5 +15,6 @@ int main()
 	gdImageLine(im, 1,1, 50, 50, gdAntiAliased);
 
 	/* Test for segfaults, if we reach this point, the test worked */
+	gdImageDestroy(im);
 	return 0;
 }

--- a/tests/gdinterpolatedscale/gdTrivialResize.c
+++ b/tests/gdinterpolatedscale/gdTrivialResize.c
@@ -51,6 +51,7 @@ void scaletest(int x, int y, int nx, int ny)
     gdTestAssert(gdMaxPixelDiff(imref, same) < CLOSE_ENOUGH);
 
     gdImageDestroy(im);
+    gdImageDestroy(imref);
     gdImageDestroy(tmp);
     gdImageDestroy(same);
 }/* scaletest*/
@@ -77,6 +78,7 @@ void do_test(int x, int y, int nx, int ny)
 
     gdImageDestroy(same);
     gdImageDestroy(im);
+    gdImageDestroy(imref);
 
     /* Scale horizontally, vertically and both. */
     scaletest(x, y, nx, y);

--- a/tests/jpeg/jpeg_read.c
+++ b/tests/jpeg/jpeg_read.c
@@ -40,6 +40,7 @@ int main()
 		return 1;
 	}
 
+	gdImageDestroy(im);
 	return 0;
 #endif
 }


### PR DESCRIPTION
I've been looking at the Travis CI setup for libgd, and I had some suggestions:

 - The libgd `configure` script looks to have a bug where it turns on `with_webp` even when its check fails (and this check fails on Travis's systems, causing failures for `make check`).
 - With WebP detection fixed, the `make check` target works OK and so can be re-enabled as something that should fail a build.
 - The codebase is [ASan](http://clang.llvm.org/docs/AddressSanitizer.html) and (mostly) [UBSan](http://clang.llvm.org/docs/UsersManual.html#controlling-code-generation) clean, so it would be nice to add build targets to keep it that way.  I also added a code coverage generation [build](https://coveralls.io/builds/4045988), but that needs the project owners to click a couple of things at [Coveralls](https://coveralls.io/).

(There's a [set of builds](https://travis-ci.org/daviddrysdale/libgd/builds/89238693) visible at Travis with my changes.)