### PR TITLE
win: Use an external snprintf hook

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,12 @@ SET (LIBGD_SRC_FILES
 	gd_version.c
 )
 
+if(MSVC AND MSVC_VERSION LESS 1900)
+	set(LIBGD_SRC_FILES ${LIBGD_SRC_FILES}
+		snprintf.c
+	)
+endif(MSVC AND MSVC_VERSION LESS 1900)
+
 include(GNUInstallDirs)
 add_library(${GD_LIB} ${LIBGD_SRC_FILES})
 add_library(${GD_LIB_STATIC} STATIC  ${LIBGD_SRC_FILES})

--- a/src/gd.h
+++ b/src/gd.h
@@ -2,6 +2,7 @@
 extern "C" {
 #endif
 
+#include <stdlib.h>
 
 #ifndef GD_H
 #define GD_H 1
@@ -88,9 +89,9 @@ extern "C" {
 #  ifndef strcasecmp
 #    define strcasecmp _stricmp
 #  endif 
-#  ifndef snprintf 
-#   define snprintf _snprintf
-#  endif 
+#if _MSC_VER < 1900
+     extern int snprintf(char*, size_t, const char*, ...);
+#endif
 #endif 
 
 #ifdef __cplusplus

--- a/src/gd_gd2.c
+++ b/src/gd_gd2.c
@@ -14,11 +14,9 @@
 #include "config.h"
 #endif
 
-#include <stdio.h>
 /* 2.0.29: no more errno.h, makes windows happy */
 #include <math.h>
 #include <string.h>
-#include <stdlib.h>
 #include "gd.h"
 #include "gd_errors.h"
 #include "gdhelpers.h"
@@ -1056,15 +1054,55 @@ BGD_DECLARE(void *) gdImageGd2Ptr (gdImagePtr im, int cs, int fmt, int *size)
 }
 
 #else /* no HAVE_LIBZ */
-BGD_DECLARE(gdImagePtr) gdImageCreateFromGd2 (FILE * inFile)
+static void _noLibzError (void)
 {
 	gd_error("GD2 support is not available - no libz\n");
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromGd2 (FILE * inFile)
+{
+	_noLibzError();
 	return NULL;
 }
 
 BGD_DECLARE(gdImagePtr) gdImageCreateFromGd2Ctx (gdIOCtxPtr in)
 {
-	gd_error("GD2 support is not available - no libz\n");
+	_noLibzError();
 	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromGd2Part (FILE * inFile, int srcx, int srcy, int w, int h)
+{
+	_noLibzError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromGd2Ptr (int size, void *data)
+{
+	_noLibzError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromGd2PartCtx (gdIOCtx * in, int srcx, int srcy, int w, int h)
+{
+	_noLibzError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromGd2PartPtr (int size, void *data, int srcx, int srcy, int w,
+        int h)
+{
+	_noLibzError();
+	return NULL;
+}
+
+BGD_DECLARE(void) gdImageGd2 (gdImagePtr im, FILE * outFile, int cs, int fmt)
+{
+	_noLibzError();
+}
+
+BGD_DECLARE(void *) gdImageGd2Ptr (gdImagePtr im, int cs, int fmt, int *size)
+{
+	_noLibzError();
 }
 #endif /* HAVE_LIBZ */

--- a/src/snprintf.c
+++ b/src/snprintf.c
@@ -1,0 +1,25 @@
+/* Provide a snprintf on Windows for older Visual Studio builds.
+ * VS2013 and older do not support C99 snprintf(). The subsitute _snprintf()
+ * does not correctly NUL-terminate buffers in case of overflow.
+ * This implementation emulates the ISO C99 snprintf() for VS2013 and older.
+ */
+
+#if defined(_MSC_VER) && _MSC_VER < 1900
+
+#include <stdio.h>
+#include <stdarg.h>
+
+int snprintf(char* buf, size_t len, const char* fmt, ...)
+{
+  int n;
+  va_list ap;
+  va_start(ap, fmt);
+
+  n = _vscprintf(fmt, ap);
+  vsnprintf_s(buf, len, _TRUNCATE, fmt, ap);
+
+  va_end(ap);
+  return n;
+}
+
+#endif


### PR DESCRIPTION
Fact 1: VS2015 has `snprintf`. Redefinition causes error.
Fact 2: `snprintf` and `_snprintf` differ as `_snprintf` doesn't zero-terminate the buffer on overflow.

* For VS2013 and below, it will compile and additional file `src/snprintf.c`, which contains the fallback implementation. The
function is included with `extern` in other files where required.
* In `src/CMakeLists.txt`, `snprintf.c` is included in sources conditionally; only for
VS2013 and below.
* Note that I have also guarded it with condition inside the `snprintf.c` file, so if any consumer/downstream is not using `cmake` but their own build system (say gyp), this will still prevent them redefining snprintf for VS2015 even if they add `src/snprintf.c` in to-be-compiled sources unconditionally.

Related work: https://github.com/libuv/libuv/pull/532.

---
Also added missing methods for absent libz case in `src/gd_gd2.c` (the build was failing with `unresolved symbol`) and bring about minor refactoring (removed redundant includes and DRY the missing libz runtime error).

---

Tested on Windows 7 with VS2013 and Windows 10 with VS2015. The current master does not compile in both environments; due to `snprintf` redefined in case of VS2015 and then in both envrionments, when gd2 libz are absent, the missing functions cause `unresolved symbol` error for each missing function.