### PR TITLE
configure: unify library tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,272 +105,148 @@ AC_CHECK_HEADERS(iconv.h,
 dnl do we need to specify -lm explicitly?
 AC_CHECK_FUNC(sin,,[AC_CHECK_LIB(m,sin)])
 
-dnl zlib is required
-AC_ARG_WITH([zlib],
-  [AS_HELP_STRING([--with-zlib@<:@=DIR@:>@], [where to find the zlib library])])
-if test "$with_zlib" != no; then
-  AC_CHECK_LIB(z,deflate,
-    [LIBS="-lz $LIBS"
-     AC_DEFINE(HAVE_LIBZ, 1, [Define if you have zlib.])
-     with_zlib=yes],
-    [AC_MSG_WARN([zlib is required - see http://www.gzip.org/zlib/])
-     with_zlib=no])
-fi
-AM_CONDITIONAL([HAVE_LIBZ], test "$with_zlib" = yes)
+dnl Helper macro for working with external libraries.
+dnl GD_LIB_CHECK([SYM], [FEATURE], [name], [...test...])
+dnl $1 - upper case symbol
+dnl $2 - GD feature name to track
+dnl $3 - lower case name for user
+dnl $4 - test for the feature
+dnl The test code should set gd_found_lib=yes to indicate success.
+m4_define([GD_LIB_CHECK], [dnl
+  dnl Export the flag for the user to leverage.  No other logic here.
+  AC_MSG_CHECKING([whether to support $3])
+  AC_ARG_WITH([$3],
+    [AS_HELP_STRING([--with-$3@<:@=DIR@:>@], [Support $3 (optionally in DIR)])],
+    [gd_with_lib=$withval],
+    [gd_with_lib=auto])
+  AC_MSG_RESULT([$gd_with_lib])
 
-dnl libpng is required
-AC_ARG_WITH([png],
-  [AS_HELP_STRING([--with-png@<:@=DIR@:>@], [where to find the png library])])
+  gd_found_lib=no
+  if test "$gd_with_lib" != "no"; then
+    save_CPPFLAGS=$CPPFLAGS
+    save_LDFLAGS=$LDFLAGS
+    dnl Set up default libs/cflags vars based on the path if user gave us one.
+    gd_lib_ldflags=
+    gd_lib_cflags=
+    case $gd_with_lib in
+    yes|no|auto|"") ;;
+    *)
+      if test -d "$gd_with_lib/lib"; then
+        gd_lib_ldflags="-L$gd_with_lib/lib"
+        AS_VAR_APPEND([LDFLAGS], [" $gd_lib_ldflags"])
+      fi
+      if test -d "$gd_with_lib/include"; then
+        gd_lib_cflags="-I$gd_with_lib/include"
+        AS_VAR_APPEND([CPPFLAGS], [" $gd_lib_cflags"])
+      fi
+      ;;
+    esac
+    dnl Run the test for this feature.
+    $4
+    CPPFLAGS=$save_CPPFLAGS
+    LDFLAGS=$save_LDFLAGS
 
-case $with_png in
-no) ;;
-yes|"")
-  PKG_CHECK_MODULES([LIBPNG], libpng, [
-    with_png=yes
-  ],[
-    if test "$with_png" = yes; then
-      AC_MSG_ERROR([png support requested, but not found - see http://www.libpng.org/pub/png/])
+    if test "$gd_found_lib" = "yes"; then
+      AC_DEFINE([HAVE_$1], [1], [Define if you have $3])
+      AS_VAR_APPEND([FEATURES], [" GD_$2"])
+      dnl Merge the flags into the main LIBS/CPPFLAGS.
+      $1][_LIBS="$gd_lib_ldflags $][$1][_LIBS"
+      $1][_CFLAGS="$gd_lib_cflags $][$1][_CFLAGS"
+      AS_VAR_APPEND([LIBS], [" $][$1][_LIBS"])
+      AS_VAR_APPEND([CPPFLAGS], [" $][$1][_CFLAGS"])
+    elif test "$gd_with_lib" = "yes"; then
+      AC_MSG_ERROR([$3 requested but not found])
+    else
+      AC_MSG_NOTICE([Disabling support for $3])
     fi
-    with_png=no
+  fi
+  AM_CONDITIONAL([HAVE_$1], test "$gd_found_lib" = yes)
+  gd_with_$1=$gd_found_lib
+])
+
+dnl Helper macro for working with external libraries with pkg-config support.
+dnl GD_LIB_PKG_CHECK([SYM], [FEATURE], [name], [pkg-config module], [...fallback test...])
+dnl $1 - upper case symbol
+dnl $2 - GD feature name to track
+dnl $3 - lower case name for user
+dnl $4 - pkg-config module to look for
+dnl $5 - fallback test for the feature
+m4_define([GD_LIB_PKG_CHECK], [dnl
+  GD_LIB_CHECK([$1], [$2], [$3], [dnl
+    PKG_CHECK_MODULES([$1], [$4], [gd_found_lib=yes], [$5])
   ])
-  ;;
-*)
-  AC_MSG_CHECKING([libpng-config script])
-  LIBPNG_CONFIG=$with_png/bin/libpng-config
+])
+
+dnl Check for zlib support.
+GD_LIB_PKG_CHECK([LIBZ], [ZLIB], [zlib], [zlib], [dnl
+  AC_CHECK_LIB([z], [deflate], [dnl
+    AS_VAR_APPEND([LIBZ_LIBS], [" -lz"])
+    gd_found_lib=yes
+  ])
+])
+
+dnl Check for libpng support.
+GD_LIB_PKG_CHECK([LIBPNG], [PNG], [png], [libpng], [
+  LIBPNG_CONFIG=$gd_with_lib/bin/libpng-config
   if test -e "$LIBPNG_CONFIG"; then
     LIBPNG_CFLAGS=`$LIBPNG_CONFIG --cflags`
     LIBPNG_LIBS=`$LIBPNG_CONFIG --ldflags`
-    with_png=yes
-    AC_MSG_RESULT([$LIBPNG_CONFIG, cflags: $LIBPNG_CFLAGS, libs: $LIBPNG_LIBS])
-  else
-    AC_MSG_ERROR([png support requested, but not found at requested location: $LIBPNG_CONFIG])
+    gd_found_lib=yes
   fi
-  ;;
-esac
-if test "$with_png" != no; then
-  CPPFLAGS="$CPPFLAGS $LIBPNG_CFLAGS"
-  LIBS="$LIBS $LIBPNG_LIBS"
-  FEATURES="GD_PNG $FEATURES"
-  AC_DEFINE(HAVE_LIBPNG, 1, [Define if you have the png library.])
-fi
-AM_CONDITIONAL([HAVE_LIBPNG], test "$with_png" = yes)
+])
 
-dnl FreeType configure tests snarfed from libwmf ..
-AC_ARG_WITH([freetype],
-  [AS_HELP_STRING([--with-freetype@<:@=DIR@:>@], [where to find the freetype 2.x library])])
-
-case $with_freetype in
-no) ;;
-yes|"")
-  dnl All freetype2 versions are numerically much larger than the actual
-  dnl version number you see in the tarball.  This is because the number
-  dnl corresponds to the shared library version rather than the release.
-  dnl 9.8.3 is the version that freetype2-2.1.10 used.
-  PKG_CHECK_MODULES([LIBFREETYPE], [freetype2 >= 9.8.3], [
-    with_freetype=yes
-  ],[
-    if test "$with_freetype" = yes; then
-      AC_MSG_ERROR([freetype support requested, but not found])
-    fi
-    with_freetype=no
-  ])
-  ;;
-*)
-  FREETYPE_CONFIG=$with_freetype/bin/freetype-config
+dnl Check for FreeType support.
+GD_LIB_PKG_CHECK([LIBFREETYPE], [FREETYPE], [freetype], [freetype2 >= 9.8.3], [
+  FREETYPE_CONFIG=$gd_with_lib/bin/freetype-config
   if test -e "$FREETYPE_CONFIG"; then
     LIBFREETYPE_CFLAGS=`$FREETYPE_CONFIG --cflags`
     LIBFREETYPE_LIBS=`$FREETYPE_CONFIG --libs`
-    with_freetype=yes
-  else
-    AC_MSG_ERROR([freetype support requested, but not found: $FREETYPE_CONFIG])
+    gd_found_lib=yes
   fi
-  ;;
-esac
-if test "$with_freetype" = yes; then
-  CPPFLAGS="$CPPFLAGS $LIBFREETYPE_CFLAGS"
-  LIBS="$LIBS $LIBFREETYPE_LIBS"
-  FEATURES="GD_FREETYPE $FEATURES"
-  AC_DEFINE(HAVE_LIBFREETYPE, 1, [Define if you have the freetype library.])
-  AC_DEFINE(HAVE_FT2BUILD_H, 1, [Define if you have the ft2build.h header.])
+])
+if test "$gd_with_LIBFREETYPE" = "yes"; then
+  AC_DEFINE([HAVE_FT2BUILD_H], [1], [Define if you have the ft2build.h header.])
 fi
-AM_CONDITIONAL([HAVE_LIBFREETYPE], test "$with_freetype" = yes)
 
-dnl check for libfontconfig by default
-AC_ARG_WITH([fontconfig],
-  [AS_HELP_STRING([--with-fontconfig@<:@=DIR@:>@], [where to find the fontconfig library])])
-
-case $with_fontconfig in
-no) ;;
-yes|"")
-  PKG_CHECK_MODULES([LIBFONTCONFIG], fontconfig, [with_fontconfig=yes],
-  [
-    if test "$with_fontconfig" = yes; then
-      AC_MSG_ERROR([fontconfig support requested, but not found])
-    fi
-    with_fontconfig=no
+dnl Check for fontconfig support.
+GD_LIB_PKG_CHECK([LIBFONTCONFIG], [FONTCONFIG], [fontconfig], [fontconfig], [
+  AC_CHECK_LIB([fontconfig], [FcInit], [dnl
+    AS_VAR_APPEND([LIBFONTCONFIG_LIBS], [" -lfontconfig"])
+    gd_found_lib=yes
   ])
-  ;;
-*)
-  save_LIBS="$LIBS"
-  save_CPPFLAGS="$CPPFLAGS"
+])
 
-  if test -d "$with_fontconfig"; then
-    LIBFONTCONFIG_CFLAGS="-I$with_fontconfig/include"
-    LIBFONTCONFIG_LIBS="-L$with_fontconfig/lib"
-  fi
-
-  CPPFLAGS="$CPPFLAGS $LIBFONTCONFIG_CFLAGS"
-  LIBS="$LIBS $LIBFONTCONFIG_LIBS"
-
-  AC_CHECK_LIB(fontconfig, FcInit,
-    [
-      LIBFONTCONFIG_LIBS="$LIBFONTCONFIG_LIBS -lfontconfig"
-      with_fontconfig=yes
-    ],[
-      if test "$with_fontconfig" != ""; then
-        AC_MSG_ERROR([fontconfig support requested, but not found])
-      else
-        with_fontconfig=no
-      fi
-    ])
-
-  CPPFLAGS="$save_CPPFLAGS"
-  LIBS="$save_LIBS"
-  ;;
-esac
-
-if test "$with_fontconfig" != no; then
-  CPPFLAGS="$CPPFLAGS $LIBFONTCONFIG_CFLAGS"
-  LIBS="$LIBS $LIBFONTCONFIG_LIBS -lfontconfig"
-  FEATURES="GD_FONTCONFIG $FEATURES"
-  AC_DEFINE(HAVE_LIBFONTCONFIG, 1, [ Define if you have the fontconfig library. ])
-fi
-AM_CONDITIONAL([HAVE_LIBFONTCONFIG], test "$with_fontconfig" = yes)
-
-dnl check for libjpeg by default
-AC_ARG_WITH([jpeg],
-  [AS_HELP_STRING([--with-jpeg@<:@=DIR@:>@], [where to find the jpeg library])],
-  [if test -d "$withval"; then
-     LDFLAGS="$LDFLAGS -L$withval/lib"
-     CFLAGS="$CFLAGS -I$withval/include"
-   fi],
-  withval=yes)
-
-if test "$withval" != no; then
-  AC_CHECK_LIB(jpeg,jpeg_set_defaults,
-    [LIBS="-ljpeg $LIBS" 
-     FEATURES="GD_JPEG $FEATURES"
-     AC_DEFINE(HAVE_LIBJPEG, 1, [ Define if you have the jpeg library. ])])
-else
-  ac_cv_lib_jpeg_jpeg_set_defaults=no
-fi
-AM_CONDITIONAL([HAVE_LIBJPEG], test "$ac_cv_lib_jpeg_jpeg_set_defaults" = yes)
-
-dnl check for libXpm by default
-AC_ARG_WITH([xpm],
-  [AS_HELP_STRING([--with-xpm@<:@=DIR@:>@], [where to find the xpm library])])
-
-case $with_xpm in
-no) ;;
-yes|"")
-  PKG_CHECK_MODULES([LIBXPM], xpm, [with_xpm=yes],
-  [
-    if test "$with_xpm" = yes; then
-      AC_MSG_ERROR([Xpm support requested, but not found])
-    fi
-    with_xpm=no
+dnl Check for jpeg support.
+GD_LIB_CHECK([LIBJPEG], [JPEG], [jpeg], [
+  AC_CHECK_LIB([jpeg], [jpeg_set_defaults], [dnl
+    AS_VAR_APPEND([LIBJPEG_LIBS], [" -ljpeg"])
+    gd_found_lib=yes
   ])
-  ;;
-*)
-  save_LIBS="$LIBS"
-  save_CPPFLAGS="$CPPFLAGS"
+])
 
-  if test -d "$with_xpm"; then
-    LIBXPM_CFLAGS="-I$with_xpm/include"
-    LIBXPM_LIBS="-L$with_xpm/lib -lXpm"
-  fi
-
-  CPPFLAGS="$CPPFLAGS $LIBXPM_CFLAGS"
-  LIBS="$LIBS $LIBXPM_LIBS"
-
-  AC_CHECK_LIB(Xpm,XpmReadFileToXpmImage,
-    [
-      if test -z "$LIBXPM_LIBS"; then
-        LIBXPM_LIBS="-lXpm"
-      fi
-      with_xpm=yes
-    ],[
-      if test "$with_xpm" != ""; then
-        AC_MSG_ERROR([Xpm support requested, but not found])
-      else
-        with_xpm=no
-      fi
-    ])
-
-  CPPFLAGS="$save_CPPFLAGS"
-  LIBS="$save_LIBS"
-  ;;
-esac
-
-if test "$with_xpm" != no; then
-  CPPFLAGS="$CPPFLAGS $LIBXPM_CFLAGS"
-  LIBS="$LIBS $LIBXPM_LIBS"
-  FEATURES="GD_XPM $FEATURES"
-  AC_DEFINE(HAVE_LIBXPM, 1, [ Define if you have the Xpm library. ])
-fi
-AM_CONDITIONAL([HAVE_LIBXPM], test "$with_xpm" = yes)
-
-dnl check for libtiff by default
-AC_ARG_WITH([tiff],
-  [AS_HELP_STRING([--with-tiff@<:@=DIR@:>@], [where to find the tiff library])])
-
-case $with_tiff in
-no) ;;
-yes|"")
-  PKG_CHECK_MODULES([LIBTIFF], libtiff-4, [with_tiff=yes],
-  [
-    if test "$with_tiff" = yes; then
-      AC_MSG_ERROR([TIFF support requested, but not found])
-    fi
-    with_tiff=no
+dnl Check for xpm support.
+GD_LIB_PKG_CHECK([LIBXPM], [XPM], [xpm], [xpm], [
+  AC_CHECK_LIB([Xpm], [XpmReadFileToXpmImage], [dnl
+    AS_VAR_APPEND([LIBXPM_LIBS], [" -lXpm"])
+    gd_found_lib=yes
   ])
-  ;;
-*)
-  save_CPPFLAGS="$CPPFLAGS"
-  save_LIBS="$LIBS"
+])
 
-  if test -d "$with_tiff"; then
-    LIBTIFF_CFLAGS="-I$with_tiff/include"
-    LIBTIFF_LIBS="-L$with_tiff/lib"
-  fi
+dnl Check for tiff support.
+GD_LIB_PKG_CHECK([LIBTIFF], [TIFF], [tiff], [libtiff-4], [
+  AC_CHECK_LIB([tiff], [TIFFClientOpen], [dnl
+    AS_VAR_APPEND([LIBTIFF_LIBS], [" -ltiff"])
+    gd_found_lib=yes
+  ])
+])
 
-  CPPFLAGS="$CPPFLAGS $LIBTIFF_CFLAGS"
-  LIBS="$LIBS $LIBTIFF_LIBS"
-
-  AC_CHECK_LIB(tiff,TIFFClientOpen,
-    [
-      LIBTIFF_LIBS="$LIBTIFF_LIBS -ltiff"
-      with_tiff=yes
-    ],[
-      if test "$with_tiff" != ""; then
-        AC_MSG_ERROR([tiff support requested, but not found])
-      else
-        with_tiff=no
-      fi
-    ])
-
-  CPPFLAGS="$save_CPPFLAGS"
-  LIBS="$save_LIBS"
-  ;;
-esac
-
-if test "$with_tiff" != no; then
-  CPPFLAGS="$CPPFLAGS $LIBTIFF_CFLAGS"
-  LIBS="$LIBS $LIBTIFF_LIBS"
-  FEATURES="GD_TIFF $FEATURES"
-  AC_DEFINE(HAVE_LIBTIFF, 1, [ Define if you have the Tiff library. ])
-fi
-AM_CONDITIONAL([HAVE_LIBTIFF], test "$with_tiff" = yes)
+dnl Check for webp support.
+GD_LIB_CHECK([LIBWEBP], [WEBP], [webp], [
+  AC_CHECK_LIB([webp], [WebPGetInfo], [dnl
+    AS_VAR_APPEND([LIBWEBP_LIBS], [" -lwebp"])
+    gd_found_lib=yes
+  ])
+])
 
 gl_VISIBILITY()
 CFLAGS="$CFLAGS $CFLAG_VISIBILITY"
@@ -383,39 +259,18 @@ if test "$mingw_cv_win32_host" = yes; then
 AC_DEFINE([BGDWIN32], [], [Define is you are building for Win32 API])
 fi
 
-
-dnl check for libwebp by default
-AC_ARG_WITH([webp],
-  [AS_HELP_STRING([--with-webp@<:@=DIR@:>@], [where to find the webp library])],
-  [if test -d "$withval"; then
-     LDFLAGS="$LDFLAGS -L$withval/lib"
-     CFLAGS="$CFLAGS -I$withval/include"
-   fi],
-  withval=yes)
-
-if test "$withval" != no; then
-  AC_CHECK_LIB(webp,WebPGetInfo,
-    [LIBS="-lwebp $LIBS" 
-     FEATURES="GD_WEBP $FEATURES"
-     AC_DEFINE(HAVE_LIBWEBP, 1, [ Define if you have the webp library. ])])
-     with_webp=yes
-else
-  with_webp=no
-fi
-AM_CONDITIONAL([HAVE_LIBWEBP], test "$with_webp" = yes)
-
 dnl report configuration
 AC_MSG_RESULT([
 ** Configuration summary for $PACKAGE $VERSION:
 
-   Support for Zlib:                 $with_zlib
-   Support for PNG library:          $with_png
-   Support for JPEG library:         $ac_cv_lib_jpeg_jpeg_set_defaults
-   Support for WebP library:         $with_webp
-   Support for TIFF library:         $with_tiff
-   Support for Freetype 2.x library: $with_freetype
-   Support for Fontconfig library:   $with_fontconfig
-   Support for Xpm library:          $with_xpm
+   Support for Zlib:                 $gd_with_LIBZ
+   Support for PNG library:          $gd_with_LIBPNG
+   Support for JPEG library:         $gd_with_LIBJPEG
+   Support for WebP library:         $gd_with_LIBWEBP
+   Support for TIFF library:         $gd_with_LIBTIFF
+   Support for Freetype 2.x library: $gd_with_LIBFREETYPE
+   Support for Fontconfig library:   $gd_with_LIBFONTCONFIG
+   Support for Xpm library:          $gd_with_LIBXPM
    Support for pthreads:             $ax_pthread_ok
 ])
 


### PR DESCRIPTION
The various code paths were inconsistent in how they handled user flags.
Create common macros and rebase all the library checks on top of those
so we know they all stay in sync.