### PR TITLE
git,repo: Ignore build spew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,12 @@ syntax: glob
 *.exe
 *.obj
 *.dll
+*.vcxproj
+*.sln
+*.filters
+*.dir
+[Bb]in
+win32
 
 Makefile
 CMakeCache.txt


### PR DESCRIPTION
Updated `.gitignore` and tested on Windows and FreeBSD that after running `cmake . && cmake --build .` checking `git status` does not show untracked files anymore (which wasn't the case before this change).