### PR TITLE
Added support for reading and writing TIFFTAG_[XY]RESOLUTION

### DIFF
--- a/src/gd_tiff.c
+++ b/src/gd_tiff.c
@@ -282,6 +282,9 @@ void tiffWriter(gdImagePtr image, gdIOCtx *out, int bitDepth)
 	bitsPerSample = (bitDepth == 24 || bitDepth == 8) ? 8 : 1;
 	TIFFSetField(tiff, TIFFTAG_BITSPERSAMPLE, bitsPerSample);
 
+	TIFFSetField(tiff, TIFFTAG_XRESOLUTION, (float)image->res_x);
+	TIFFSetField(tiff, TIFFTAG_YRESOLUTION, (float)image->res_y);
+
 	/* build the color map for 8 bit images */
 	if(bitDepth != 24) {
 		colorMapRed   = (uint16 *) gdMalloc(3 * (1 << bitsPerSample));
@@ -795,6 +798,7 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromTiffCtx(gdIOCtx *infile)
 	char	save_transparent;
 	int		image_type;
 	int   ret;
+	float res_float;
 
 	gdImagePtr im = NULL;
 
@@ -957,7 +961,14 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromTiffCtx(gdIOCtx *infile)
 		goto error;
 	}
 
-	if (TIFFGetField (tif, TIFFTAG_ORIENTATION, &orientation)) {
+	if (TIFFGetField(tif, TIFFTAG_XRESOLUTION, &res_float)) { 
+		im->res_x = (unsigned int)res_float;  //truncate
+	}
+	if (TIFFGetField(tif, TIFFTAG_YRESOLUTION, &res_float)) { 
+		im->res_y = (unsigned int)res_float;  //truncate
+	}
+
+	if (TIFFGetField(tif, TIFFTAG_ORIENTATION, &orientation)) {
 		switch (orientation) {
 		case ORIENTATION_TOPLEFT:
 		case ORIENTATION_TOPRIGHT:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -99,6 +99,7 @@ EXTRA_PROGRAMS = \
 	wbmp/wbmp_im2im \
 	tiff/tiff_null \
 	tiff/tiff_im2im \
+	tiff/tiff_dpi \
 	freetype/bug00132 \
 	bmp/bmp_im2im \
 	gdimagescatterex/bug00208_1 \
@@ -197,7 +198,8 @@ endif
 if HAVE_LIBTIFF
 check_PROGRAMS += \
 	tiff/tiff_null \
-	tiff/tiff_im2im
+	tiff/tiff_im2im \
+	tiff/tiff_dpi
 endif
 
 if HAVE_LIBFREETYPE
@@ -371,6 +373,7 @@ CLEANFILES = \
 	png_im2im_src.png \
 	tiff_im2im_dst.tiff \
 	tiff_im2im_src.tiff \
+	tiff_dpi_src.tiff \
 	wbmp/wbmp_im2im_dst.wbmp \
 	wbmp/wbmp_im2im_src.wbmp \
 	wbmp_im2im_dst.wbmp \

--- a/tests/tiff/CMakeLists.txt
+++ b/tests/tiff/CMakeLists.txt
@@ -2,6 +2,7 @@
 SET(TESTS_FILES
 	tiff_im2im
 	tiff_null
+	tiff_dpi
 )
 
 FOREACH(test_name ${TESTS_FILES})

--- a/tests/tiff/tiff_dpi.c
+++ b/tests/tiff/tiff_dpi.c
@@ -1,0 +1,79 @@
+/* 
+ * Test that reading and writing image resolution values to/from TIFF files
+ * works correctly.  Set the image resolution, write the file, read the file
+ * back and test that the image resolution comes back correct.
+ */
+#include "gd.h"
+#include "gdtest.h"
+
+int main()
+{
+	gdImagePtr src, dst;
+	int r, res_x, res_y;
+	void *p;
+	int size = 0;
+	int status = 0;
+
+	src = gdImageCreate(100, 100);
+	if (src == NULL) {
+		printf("could not create src\n");
+		return 1;
+	}
+	r = gdImageColorAllocate(src, 0xFF, 0, 0);
+	gdImageFilledRectangle(src, 0, 0, 99, 99, r);
+
+	// gd default DPI is 96; libtiff default is 72.  
+	// Use something else so we know the value has been
+	// written / read correctly.
+	res_x = 100;
+	res_y = 200;
+	src->res_x = res_x;
+	src->res_y = res_y;
+
+#define OUTPUT_TIFF(name) do {							\
+		FILE *fp;										\
+														\
+		fp = fopen("tiff_dpi_" #name ".tiff", "wb");	\
+		if (fp) {										\
+			gdImageTiff(name, fp);						\
+			fclose(fp);									\
+		}												\
+	} while (0)
+
+	OUTPUT_TIFF(src);
+	p = gdImageTiffPtr(src, &size);
+	if (p == NULL) {
+		status = 1;
+		printf("p is null\n");
+		goto door0;
+	}
+	if (size <= 0) {
+		status = 1;
+		printf("size is non-positive\n");
+		goto door1;
+	}
+
+	dst = gdImageCreateFromTiffPtr(size, p);
+	if (dst == NULL) {
+		status = 1;
+		printf("could not create dst\n");
+		goto door1;
+	}
+
+	if (dst->res_x != res_x) {
+		status = 1;
+		printf("mismatch in res_x (got %d, expected %d)", dst->res_x, res_x);
+	}
+
+	if (dst->res_y != res_y) {
+		status = 1;
+		printf("mismatch in res_y (got %d, expected %d)", dst->res_y, res_y);
+	}
+
+	gdImageDestroy(dst);
+door1:
+	gdFree(p);
+door0:
+	gdImageDestroy(src);
+	return status;
+}


### PR DESCRIPTION
Hi!  I needed libgd to support writing out tiff files at particular DPIs, so I added a couple of lines to gd_tiff.c.  I included code to set TIFFTAG_XRESOLUTION and TIFFTAG_YRESOLUTION (including casting the uint res_x and res_y values to float).  For completeness I also added code to grab those tags when parsing a tiff, though float values will be truncated to uint.  

The existing tests should all pass.  I didn't add any tests to prove that what I did works (though it's working for me).

Cheers, 
-Matt