### PR TITLE
added a script to build the docs and put them in the gh-pages branch …

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ umbrella of PHP.net.
 
 Please visit our [homepage](http://www.libgd.org/) for more details.
 
+API documentation can be found here: http://libgd.github.io/libgd
+
 ## Supported Image Formats
 
 GD has builtin support for:

--- a/docs/naturaldocs/build_gh_pages.sh
+++ b/docs/naturaldocs/build_gh_pages.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# a very hacky script to build and push to gh-pages
+# designed to be run from master (or any branch no the gh-pages branch)
+#
+# This will publish the html docs to the github.io url:
+# http://chrisbarker-noaa.github.io/libgd
+# this needs to be updated for the "proper" repo
+
+PARENTDIR=../../../
+REPONAME=libgd.gh_pages/
+GHPAGESDIR=$PARENTDIR$REPONAME
+
+# make sure the gh pages repo is there
+if [ ! -d "$GHPAGESDIR" ]; then
+	# if it's not there yet, create a clone
+    pushd $PARENTDIR
+    ## this needs to be changed to the main repo
+    #  or, pulled from  .git configuration somehow
+    #  or can jsut make the repo by hand first.
+    git clone https://github.com/ChrisBarker-NOAA/libgd.git $REPONAME
+    popd
+fi
+
+# now put it in the right branch
+pushd $GHPAGESDIR
+git checkout gh-pages
+popd
+
+# make the docs
+./run_docs.sh
+
+# copy to other repo (on the gh-pages branch)
+cp -R html/ $GHPAGESDIR
+
+# commit and push teh updated docs to the gh_pages branch inteh other repo
+pushd $GHPAGESDIR
+git add * # in case there are new files added
+git commit -a -m "updating online docs"
+# pull any changes that someone else pushed
+#      with "ours" merge so there won't be conflicts
+git pull -s ours --no-edit
+
+# push it up to gitHub
+git push
+


### PR DESCRIPTION
…for publishing on gitHub.io

See issue #85

The script creates (or uses) a parallel clone of the repo, switches that repo to the gh-pages branch, then generate the docs and copies them to the other repo, and commits and published them there.

If the script is run on a *nix machine by someone with commit privileges to the main gitHub repo that is setup up to build the docs (i.e. has NaturalDocs), it should publish the latest.

One could set this up to be run on a CI system on every commit to master if you wanted, but I don't know how to deal with the authorization issues, so I haven't tried that.

NOTE: the script is hard-coded to my fork of the repo, so I could test it out. See the result here:

http://chrisbarker-noaa.github.io/libgd

Also -- if the script is run from a branch for a different version, that version will get published -- so probably good to use a release version.

NOTE2: this is publishing to the repos gh-pages -- as the Web site is published elsewhere. I think it should stay that way, but they could be merged if you wanted -- I'm sure there is a way to put raw html in a Jekyll site somehow.

You could do this all by hand too, but I've found it helpful to have a single script to run to update.



