### PR TITLE
Fix #170: XBM images require width to be multiple of 8

### DIFF
--- a/src/gd_xbm.c
+++ b/src/gd_xbm.c
@@ -251,7 +251,7 @@ BGD_DECLARE(void) gdImageXbmCtx(gdImagePtr image, char* file_name, int fg, gdIOC
 			if (gdImageGetPixel(image, x, y) == fg) {
 				c |= b;
 			}
-			if ((b == 128) || (x == sx && y == sy)) {
+			if ((b == 128) || (x == sx - 1)) {
 				b = 1;
 				if (p) {
 					gdCtxPuts(out, ", ");

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -61,6 +61,7 @@ if (BUILD_TEST)
 		tiff
 		wbmp
 		webp
+		xbm
 		xpm
 	)
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,6 +55,7 @@ include tga/Makemodule.am
 include tiff/Makemodule.am
 include wbmp/Makemodule.am
 include webp/Makemodule.am
+include xbm/Makemodule.am
 include xpm/Makemodule.am
 
 LDADD = libgdtest.a ../src/libgd.la

--- a/tests/xbm/.gitignore
+++ b/tests/xbm/.gitignore
@@ -1,0 +1,1 @@
+/github_bug_170

--- a/tests/xbm/CMakeLists.txt
+++ b/tests/xbm/CMakeLists.txt
@@ -1,0 +1,5 @@
+LIST(APPEND TESTS_FILES
+	github_bug_170
+)
+
+ADD_GD_TESTS()

--- a/tests/xbm/Makemodule.am
+++ b/tests/xbm/Makemodule.am
@@ -1,0 +1,5 @@
+libgd_test_programs += \
+	xbm/github_bug_170
+
+EXTRA_DIST += \
+	xbm/CMakeLists.txt

--- a/tests/xbm/github_bug_170.c
+++ b/tests/xbm/github_bug_170.c
@@ -1,0 +1,42 @@
+/*
+	Test writing of XBM images with a width that is not a multiple of 8
+
+	We create an image with a width of 11 pixels, and draw a circle on it.
+	To test that the padding is correctly applied, we write the image to disk
+	and assert that the number of bytes written matches our expectation.
+
+	See also <https://github.com/libgd/libgd/issues/170>.
+*/
+
+#include <inttypes.h>
+#include "gd.h"
+#include "gdtest.h"
+
+int main()
+{
+	gdImagePtr im;
+	int black;
+	FILE *outFile;
+	gdIOCtx *out;
+	off_t length;
+
+	/* create the test image */
+	im = gdImageCreate(11, 11);
+	gdImageColorAllocate(im, 255, 255, 255);
+	black = gdImageColorAllocate(im, 0, 0, 0);
+	gdImageArc(im, 5, 5, 10, 10, 0, 360, black);
+
+	/* write the file to disk, note the file length and delete the file */
+	outFile = gdTestTempFp();
+	out = gdNewFileCtx(outFile);
+	gdTestAssert(out != NULL);
+	gdImageXbmCtx(im, "github_bug_170.xbm", 1, out);
+	out->gd_free(out);
+	length = ftello(outFile);
+	fclose(outFile);
+
+	gdImageDestroy(im);
+
+	gdTestAssertMsg(length == 250, "expected to write 250 bytes; %jd bytes written", (intmax_t) length);
+	return gdNumFailures();
+}


### PR DESCRIPTION
We remove this limitation by fixing the underlying implementation bug,
and add a respective regression test to the suite.

The test is not quite like we would want it, though. Firstly, just checking the XBM to have the expected size in bytes is neither clear nor resilient[1], but checking for the exact contents appears to be overly laborious with the current testing framework. Secondly, actually writing the XBM to disk is inefficient and not really necessary, but I haven't been able to verify the result after writing the XBM to an in-memory gdIOCtx.

[1] There might be an issue on Windows due to the line endings, but I haven't been able yet to set up the necessary build environment on a Windows machine so that I could verify. If there are issues, the test could be adapted to also allow the respective file size (presumably, 256 bytes), or simply skipped on Windows, as XBM is supposed to be a *nix thing only.