### PR TITLE
tests: fix gdAssertImage helpers #228

### DIFF
--- a/tests/gdtest/gdtest.h
+++ b/tests/gdtest/gdtest.h
@@ -65,10 +65,10 @@ int _gdTestErrorMsg(const char* file, unsigned int line, const char* string, ...
 
 /* public assert functions */
 #define gdAssertImageEqualsToFile(ex,ac) gdTestImageCompareToFile(__FILE__,__LINE__,NULL,(ex),(ac))
-#define gdAssertImageFileEqualsMsg(ex,ac) gdTestImageCompareFiles(__FILE__,__LINE__,(ms),(ex),(ac))
+#define gdAssertImageFileEqualsMsg(ex,ac,ms) gdTestImageCompareFiles(__FILE__,__LINE__,(ms),(ex),(ac))
 
-#define gdAssertImageEquals(tc,ex,ac) CuAssertImageEquals_LineMsg((tc),__FILE__,__LINE__,NULL,(ex),(ac))
-#define gdAssertImageEqualsMsg(tc,ex,ac) CuAssertImageEquals_LineMsg((tc),__FILE__,__LINE__,(ms),(ex),(ac))
+#define gdAssertImageEquals(ex,ac) gdTestImageCompareToImage(__FILE__,__LINE__,NULL,(ex),(ac))
+#define gdAssertImageEqualsMsg(ex,ac,ms) gdTestImageCompareToImage(__FILE__,__LINE__,(ms),(ex),(ac))
 
 #define gdTestAssert(cond) _gdTestAssert(__FILE__, __LINE__, (cond))
 


### PR DESCRIPTION
The non-existing CuAssertImageEquals_LineMsg() is replaced by
gdTestImageCompareToImage(), and while we're at it, we fix
gdAssertImageFileEqualsMsg() as well, which didn't accept the ms argument,
which would have been required though.

To be able to test that these macros work, it would be reasonable to have
some tests using them. An alternative would be to have tests for the test
utitlities, but I'm not a big fan of this.