### PR TITLE
Fix some issues reported by Coverity

### DIFF
--- a/src/gd.c
+++ b/src/gd.c
@@ -1912,10 +1912,6 @@ BGD_DECLARE(void) gdImageFilledEllipse (gdImagePtr im, int mx, int my, int w, in
 		if(old_y2!=my2) {
 			for(i=mx1; i<=mx2; i++) {
 				gdImageSetPixel(im,i,my1,c);
-			}
-		}
-		if(old_y2!=my2) {
-			for(i=mx1; i<=mx2; i++) {
 				gdImageSetPixel(im,i,my2,c);
 			}
 		}

--- a/src/gdft.c
+++ b/src/gdft.c
@@ -448,12 +448,8 @@ static int useFontConfig(int flag)
 #ifdef HAVE_LIBFONTCONFIG
 	if (fontConfigFlag) {
 		return (!(flag & gdFTEX_FONTPATHNAME));
-	} else
-#endif
-	{
-		return flag & gdFTEX_FONTCONFIG;
-		
 	}
+#endif
 	return flag & gdFTEX_FONTCONFIG;
 }
 
@@ -734,8 +730,6 @@ gdft_draw_bitmap (gdCache_head_t * tc_cache, gdImage * im, int fg,
 				                + bitmap.num_grays / 2)
 				               / (bitmap.num_grays - 1);
 			} else if (bitmap.pixel_mode == ft_pixel_mode_mono) {
-				tc_key.pixel = ((bitmap.buffer[pc / 8]
-				                 << (pc % 8)) & 128) ? GD_NUMCOLORS : 0;
 				/* 2.0.5: mode_mono fix from Giuliano Pochini */
 				tc_key.pixel =
 				    ((bitmap.


### PR DESCRIPTION
* Unused value in gdft.c (ID 102122)
  Apparently, that's a leftover from the "mode_mono fix from Giuliano
  Pochini".
* Structurally dead code in gdft.c (ID 95850)
  We can slightly refactor the code to not use an `else` clause at all,
  what also makes the code cleaner.
* Copy-paste error in gd.c (ID 95837)
  Comparing that with [PHP's bundled libgd](https://github.com/php/php-src/blob/php-7.0.7/ext/gd/libgd/gd_arc.c#L94-L99)
  it appears that the duplication of the condition and the loop is useless.
  I'm not sure about that, though.