### PR TITLE
Fix issue #276: Sometimes pixels are missing when storing images as BMPs

### DIFF
--- a/src/gd_bmp.c
+++ b/src/gd_bmp.c
@@ -395,9 +395,7 @@ static int compress_row(unsigned char *row, int length)
 	}
 
 	if (compressed_run) {
-		if (rle_type == BMP_RLE_TYPE_RLE) {
-			compressed_length += build_rle_packet(row, rle_type, compressed_run, uncompressed_row);
-		}
+		compressed_length += build_rle_packet(row, rle_type, compressed_run, uncompressed_row);
 	}
 
 	gdFree(uncompressed_start);

--- a/tests/bmp/.gitignore
+++ b/tests/bmp/.gitignore
@@ -1,3 +1,4 @@
 /bmp_im2im
 /bmp_null
 /bug00275
+/bug00276

--- a/tests/bmp/CMakeLists.txt
+++ b/tests/bmp/CMakeLists.txt
@@ -2,6 +2,7 @@ LIST(APPEND TESTS_FILES
 	bmp_im2im
 	bmp_null
 	bug00275
+	bug00276
 )
 
 ADD_GD_TESTS()

--- a/tests/bmp/Makemodule.am
+++ b/tests/bmp/Makemodule.am
@@ -1,6 +1,7 @@
 libgd_test_programs += \
 	bmp/bmp_null \
-	bmp/bug00275
+	bmp/bug00275 \
+	bmp/bug00276
 
 if HAVE_LIBPNG
 libgd_test_programs += \

--- a/tests/bmp/bug00276.c
+++ b/tests/bmp/bug00276.c
@@ -1,0 +1,32 @@
+/* See <https://github.com/libgd/libgd/issues/276> */
+
+
+#include "gd.h"
+#include "gdtest.h"
+
+
+int main()
+{
+	gdImagePtr im_orig, im_saved;
+	int white;
+	void *data;
+	int size;
+
+	/* create an image */
+	im_orig = gdImageCreate(10, 10);
+	gdImageColorAllocate(im_orig, 0, 0, 0);
+	white = gdImageColorAllocate(im_orig, 255, 255, 255);
+	gdImageLine(im_orig, 0,0, 9,9, white);
+
+	/* save the image, re-read it and compare it with the original */
+	data = gdImageBmpPtr(im_orig, &size, 1);
+	im_saved = gdImageCreateFromBmpPtr(size, data);
+	gdTestAssert(im_saved != NULL);
+	gdAssertImageEquals(im_orig, im_saved);
+
+	/* clean up */
+	gdImageDestroy(im_orig);
+	gdImageDestroy(im_saved);
+
+	return gdNumFailures();
+}


### PR DESCRIPTION
That happens only when RLE is applied. The culprit is in compress_row(),
where the rightmost pixels which wouldn't be run-length encoded were
ignored; instead we now add them uncompressed to the `row`.