### PR TITLE
Hack to work around NaturalDocs encoding issues

### DIFF
--- a/docs/naturaldocs/run_docs.sh
+++ b/docs/naturaldocs/run_docs.sh
@@ -64,6 +64,9 @@ echo "Title: License" | cat - ../../COPYING > tmp/license.txt
 sed -e "s/@VERSION@/$VERSION/g" preamble.txt > tmp/preamble.txt
 # ^^^ hack to get the version number in the docs.
 
+# Hack to work around NaturalDocs encoding issues
+iconv -f UTF-8 -t ISO-8859-1 -o tmp/license.txt tmp/license.txt
+
 # Run naturaldocs to create the manual.
 $(nd) --rebuild --rebuild-output --documented-only \
     -i tmp/ \


### PR DESCRIPTION
NaturalDocs appears to assume that its input is ANSI encoded, so feeding
in UTF-8 encoded files will result in faulty character conversions even
though the system locale is set to UTF-8. This can be seen on
<https://libgd.github.io/manuals/2.2.3/files/license-txt.html>, where
Jaakko Hyvätti's name is garbled.

We work around this issue by explicitly iconv'erting the license file.
Other files don't seem to be affected, as these use ASCII characters only.