### PR TITLE
Fix integer overflow in gdImageWebpCtx

### DIFF
--- a/src/gd_webp.c
+++ b/src/gd_webp.c
@@ -199,6 +199,14 @@ BGD_DECLARE(void) gdImageWebpCtx (gdImagePtr im, gdIOCtx * outfile, int quality)
 		quality = 80;
 	}
 
+	if (overflow2(gdImageSX(im), 4)) {
+		return;
+	}
+
+	if (overflow2(gdImageSX(im) * 4, gdImageSY(im))) {
+		return;
+	}
+
 	argb = (uint8_t *)gdMalloc(gdImageSX(im) * 4 * gdImageSY(im));
 	if (!argb) {
 		return;


### PR DESCRIPTION
Integer overflow can be happened in expression ``gdImageSX(im) * 4 * gdImageSY(im)``. It could lead to heap buffer overflow in the following code. 

This issue has been reported to the PHP Bug Tracking System. The proof-of-concept file will be supplied some days later. 

This issue was discovered by Ke Liu of Tencent's Xuanwu LAB.