### PR TITLE
Fix #93: gdImageScaleTwoPass() looses top row and left column

### DIFF
--- a/src/gd_interpolation.c
+++ b/src/gd_interpolation.c
@@ -884,12 +884,15 @@ static inline LineContribType *_gdContributionsCalc(unsigned int line_size, unsi
 	int windows_size;
 	unsigned int u;
 	LineContribType *res;
+	double shift;
 
 	if (scale_d < 1.0) {
 		width_d = filter_width_d / scale_d;
 		scale_f_d = scale_d;
+		shift = 1 / (2 * scale_d) - 0.5;
 	}  else {
 		width_d= filter_width_d;
+		shift = -(((line_size - 1) / scale_d - (src_size - 1)) / 2);
 	}
 
 	windows_size = 2 * (int)ceil(width_d) + 1;
@@ -898,7 +901,7 @@ static inline LineContribType *_gdContributionsCalc(unsigned int line_size, unsi
 		return NULL;
 	}
 	for (u = 0; u < line_size; u++) {
-		const double dCenter = (double)u / scale_d;
+		const double dCenter = (double)u / scale_d + shift;
 		/* get the significant edge points affecting the pixel */
 		register int iLeft = MAX(0, (int)floor (dCenter - width_d));
 		int iRight = MIN((int)ceil(dCenter + width_d), (int)src_size - 1);

--- a/tests/gdimagescale/.gitignore
+++ b/tests/gdimagescale/.gitignore
@@ -1,3 +1,4 @@
+/bug00093
 /bug00329
 /bug00330
 /github_bug_00218

--- a/tests/gdimagescale/CMakeLists.txt
+++ b/tests/gdimagescale/CMakeLists.txt
@@ -1,4 +1,5 @@
 LIST(APPEND TESTS_FILES
+	bug00093
 	bug00329
 	bug00330
 	github_bug_00218

--- a/tests/gdimagescale/Makemodule.am
+++ b/tests/gdimagescale/Makemodule.am
@@ -1,5 +1,6 @@
 
 libgd_test_programs += \
+	gdimagescale/bug00093 \
 	gdimagescale/bug00329 \
 	gdimagescale/bug00330 \
 	gdimagescale/github_bug_00218 \

--- a/tests/gdimagescale/bug00093.c
+++ b/tests/gdimagescale/bug00093.c
@@ -1,0 +1,80 @@
+/**
+ * Regression test for <https://github.com/libgd/libgd/issues/93>
+ *
+ * We're drawing a black rectangle along the border of a white image, and
+ * check that sample points near the corners of the scaled image have a red
+ * channel value below a certain threshold, i.e. are gray and not white. We
+ * don't check against exact values to avoid potential precision issues as
+ * floating point arithmethic is involved in the scaling algorithm.
+ */
+
+
+#include "gd.h"
+#include "gdtest.h"
+
+
+static void check_upscaled_pixel(gdImagePtr im, int x, int y)
+{
+    int red = gdTrueColorGetRed(gdImageGetPixel(im, x, y));
+    
+    gdTestAssertMsg(red < 128, "pixel %d,%d: expected red < 128, but got %d", x, y, red);
+}
+
+
+static void check_upscale()
+{
+    gdImagePtr src, dst;
+
+    src = gdImageCreateTrueColor(11, 11);
+    gdImageFilledRectangle(src, 0, 0, 10, 10, gdTrueColorAlpha(255, 255, 255, gdAlphaOpaque));
+    gdImageRectangle(src, 0, 0, 10, 10, gdTrueColorAlpha(0, 0, 0, gdAlphaOpaque));
+
+    gdImageSetInterpolationMethod(src, GD_TRIANGLE);
+    dst = gdImageScale(src, 132, 132);
+
+    check_upscaled_pixel(dst, 11, 11);
+    check_upscaled_pixel(dst, 11, 120);
+    check_upscaled_pixel(dst, 120, 11);
+    check_upscaled_pixel(dst, 120, 120);
+
+    gdImageDestroy(src);
+    gdImageDestroy(dst);
+}
+
+
+static void check_downscaled_pixel(gdImagePtr im, int x, int y)
+{
+    int red = gdTrueColorGetRed(gdImageGetPixel(im, x, y));
+    
+    gdTestAssertMsg(red < 240, "pixel %d,%d: expected red < 240, but got %d", x, y, red);
+}
+
+
+static void check_downscale()
+{
+    gdImagePtr src, dst;
+
+    src = gdImageCreateTrueColor(132, 132);
+    gdImageFilledRectangle(src, 0, 0, 131, 131, gdTrueColorAlpha(255, 255, 255, gdAlphaOpaque));
+    gdImageRectangle(src, 0, 0, 131, 131, gdTrueColorAlpha(0, 0, 0, gdAlphaOpaque));
+
+    gdImageSetInterpolationMethod(src, GD_TRIANGLE);
+    dst = gdImageScale(src, 11, 11);
+
+    check_downscaled_pixel(dst, 0, 0);
+    check_downscaled_pixel(dst, 0, 10);
+    check_downscaled_pixel(dst, 10, 0);
+    check_downscaled_pixel(dst, 10, 10);
+
+    gdImageDestroy(src);
+    gdImageDestroy(dst);
+}
+
+
+int main()
+{
+    check_upscale();
+    check_downscale();
+
+    return gdNumFailures();
+}


### PR DESCRIPTION
Because we're dealing with pixels, opposed to mathematical points, we
have to adjust `dCenter` appropriately. For upscaling we have to shift
the center to the left, for downscaling we have to shift to the right.
