### PR TITLE
Enable test case on Windows

### DIFF
--- a/tests/xbm/github_bug_170.c
+++ b/tests/xbm/github_bug_170.c
@@ -8,24 +8,16 @@
 	See also <https://github.com/libgd/libgd/issues/170>.
 */
 
-#include <inttypes.h>
 #include "gd.h"
 #include "gdtest.h"
-#ifdef _WIN32
 
-int main()
-{
-	/* skip for now */
-	return 0;
-}
-#else
 int main()
 {
 	gdImagePtr im;
 	int black;
 	FILE *outFile;
 	gdIOCtx *out;
-	off_t length;
+	long length;
 
 	/* create the test image */
 	im = gdImageCreate(11, 11);
@@ -39,12 +31,11 @@ int main()
 	gdTestAssert(out != NULL);
 	gdImageXbmCtx(im, "github_bug_170.xbm", 1, out);
 	out->gd_free(out);
-	length = ftello(outFile);
+	length = ftell(outFile);
 	fclose(outFile);
 
 	gdImageDestroy(im);
 
-	gdTestAssertMsg(length == 250, "expected to write 250 bytes; %jd bytes written", (intmax_t) length);
+	gdTestAssertMsg(length == 250, "expected to write 250 bytes; %ld bytes written", length);
 	return gdNumFailures();
 }
-#endif


### PR DESCRIPTION
This test case has been disabled for Windows, because even MSVC 14
doesn't know ftello(), which is a Posix extension to the ISO standard.

Actually, ftell() is supposed to work fine for this test too, as we
don't have to deal with a large file, and we're comparing to a fixed
expected length, anyway.