### PR TITLE
cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,8 +258,11 @@ else(WIN32)
 endif(WIN32)
 
 IF (ENABLE_LIQ AND LIQ_BUILD)
+  if (BUILD_SHARED_LIBS)
     ADD_DEPENDENCIES(${GD_LIB} libimagequant)
+  elseif (BUILD_STATIC_LIBS)
     ADD_DEPENDENCIES(${GD_LIB_STATIC} libimagequant)
+  endif()
 ENDIF(ENABLE_LIQ AND LIQ_BUILD)
 
 

--- a/cmake/modules/FindLIQ.cmake
+++ b/cmake/modules/FindLIQ.cmake
@@ -44,7 +44,7 @@ ELSE (LIQ_FOUND)
           INSTALL_DIR libimagequant
           INSTALL_COMMAND true
           CONFIGURE_COMMAND true
-          BUILD_COMMAND make static CFLAGSADD='-fPIC'
+          BUILD_COMMAND $(MAKE) static CFLAGSADD='-fPIC'
       )
 
       SET(LIQ_FOUND "SORTOF")


### PR DESCRIPTION
when building libgb with libimagequant it complains about gdstatic target does not exists. first commit fixes that.

second commit uses $(MAKE) which can be gmake or make. This is required when building on bsd oses where 'make' is actually 'bsdmake' and not gnu make.