### PR TITLE
Added missing header gd_io_stream.h (fix issue #397)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -53,6 +53,7 @@ AM_INIT_AUTOMAKE([1.11 foreign dist-xz -Wall -Werror subdir-objects])
 AC_CONFIG_HEADERS([src/config.h:src/config.hin])
 
 AM_PROG_AR
+AC_PROG_CXX
 AC_PROG_CC_STDC
 AM_PROG_CC_C_O
 AC_PROG_INSTALL

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -170,6 +170,7 @@ install(FILES
 	gd_color_map.h
 	gd_errors.h
 	gd_io.h
+	gd_io_stream.h
 	gdcache.h
 	gdfontg.h
 	gdfontl.h

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -39,7 +39,21 @@ endif
 
 EXTRA_DIST = bdftogd demoin.png entities.html entities.tcl CMakeLists.txt config.h.cmake gd_io_stream.cxx gdpp.cxx msinttypes/inttypes.h msinttypes/stdint.h
 
-include_HEADERS = gd.h gdfx.h gd_io.h gdcache.h gdfontg.h gdfontl.h gdfontmb.h gdfonts.h gdfontt.h entities.h gd_color_map.h gd_errors.h gdpp.h
+include_HEADERS = \
+	entities.h \
+	gd.h \
+	gd_color_map.h \
+	gd_errors.h \
+	gd_io.h \
+	gd_io_stream.h \
+	gdcache.h \
+	gdfontg.h \
+	gdfontl.h \
+	gdfontmb.h \
+	gdfonts.h \
+	gdfontt.h \
+	gdfx.h \
+	gdpp.h
 
 lib_LTLIBRARIES = libgd.la
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -81,6 +81,7 @@ libgd_la_SOURCES = \
 	gd_io_dp.c \
 	gd_io_file.c \
 	gd_io_ss.c \
+	gd_io_stream.cxx \
 	gd_io_stream.h \
 	gd_jpeg.c \
 	gd_matrix.c \
@@ -117,6 +118,8 @@ libgd_la_SOURCES = \
 	gdhelpers.c \
 	gdhelpers.h \
 	gdkanji.c \
+	gdpp.cxx \
+	gdpp.h \
 	gdtables.c \
 	gdxpm.c \
 	jisx0208.h \


### PR DESCRIPTION
Offered for consideration. Should fix Issue #397 

Updated `src/Makefile.am` and `src/CMakeLists.txt` to include the missing file.
Also moved header includes from all on one line to separate lines as it was getting a little long.

