### PR TITLE
Truetype font drawing functions now take `const` strings

### DIFF
--- a/docs/naturaldocs/project/Menu.txt
+++ b/docs/naturaldocs/project/Menu.txt
@@ -65,28 +65,28 @@ Group: Image Formats  {
    File: XPM Input  (no auto-title, gdxpm.c)
    }  # Group: Image Formats
 
+File: Color Quantization  (gd_topal.c)
+File: Cropping  (gd_crop.c)
+File: FreeType font rendering  (gdft.c)
 File: gd.c  (gd.c)
 File: gd.h  (gd.h)
-File: gd_crop.c  (gd_crop.c)
 File: gd_filename.c  (gd_filename.c)
-File: gd_filter.c  (gd_filter.c)
 File: gd_interpolation.c  (gd_interpolation.c)
 File: gd_io.h  (gd_io.h)
 File: gd_io_dp.c  (gd_io_dp.c)
 File: gd_ss.c  (gd_ss.c)
-File: gd_topal.c  (gd_topal.c)
-File: gd_transform.c  (gd_transform.c)
 File: gd_version.c  (gd_version.c)
 File: gdColorMapLookup  (gd_color_map.c)
 File: gdFree  (gdhelpers.c)
-File: gdft.c  (gdft.c)
 File: gdfx.c  (gdfx.c)
 File: gdImageColorMatch  (gd_color_match.c)
 File: gdImageNeuQuant  (gd_nnquant.c)
 File: gdNewFileCtx  (gd_io_file.c)
 File: gdNewSSCtx  (gd_io_ss.c)
+File: Image Filters  (gd_filter.c)
 File: License  (license.txt)
 File: Matrix  (gd_matrix.c)
+File: Transformations  (gd_transform.c)
 
 Group: Built-in Fonts  {
 
@@ -103,6 +103,7 @@ Group: Index  {
    Index: Everything
    File Index: Files
    Function Index: Functions
+   Macro Index: Macros
    Type Index: Types
    }  # Group: Index
 

--- a/src/gd.h
+++ b/src/gd.h
@@ -768,14 +768,14 @@ BGD_DECLARE(void) gdFontCacheShutdown (void);
 BGD_DECLARE(void) gdFreeFontCache (void);
 
 /* Calls gdImageStringFT. Provided for backwards compatibility only. */
-BGD_DECLARE(char *) gdImageStringTTF (gdImage * im, int *brect, int fg, char *fontlist,
+BGD_DECLARE(char *) gdImageStringTTF (gdImage * im, int *brect, int fg, const char *fontlist,
                                       double ptsize, double angle, int x, int y,
-                                      char *string);
+                                      const char *string);
 
 /* FreeType 2 text output */
-BGD_DECLARE(char *) gdImageStringFT (gdImage * im, int *brect, int fg, char *fontlist,
+BGD_DECLARE(char *) gdImageStringFT (gdImage * im, int *brect, int fg, const char *fontlist,
                                      double ptsize, double angle, int x, int y,
-                                     char *string);
+                                     const char *string);
 
 
 /*
@@ -857,9 +857,9 @@ BGD_DECLARE(int) gdFTUseFontConfig(int flag);
 #define gdFTEX_Big5 2
 #define gdFTEX_Adobe_Custom 3
 
-BGD_DECLARE(char *) gdImageStringFTEx (gdImage * im, int *brect, int fg, char *fontlist,
+BGD_DECLARE(char *) gdImageStringFTEx (gdImage * im, int *brect, int fg, const char *fontlist,
                                        double ptsize, double angle, int x, int y,
-                                       char *string, gdFTStringExtraPtr strex);
+                                       const char *string, gdFTStringExtraPtr strex);
 
 
 /*

--- a/src/gdft.c
+++ b/src/gdft.c
@@ -103,8 +103,8 @@ static char *font_path(char **fontpath, char *name_list);
  *
  * Alias of <gdImageStringFT>.
  */
-BGD_DECLARE(char *) gdImageStringTTF (gdImage * im, int *brect, int fg, char *fontlist,
-                                      double ptsize, double angle, int x, int y, char *string)
+BGD_DECLARE(char *) gdImageStringTTF (gdImage * im, int *brect, int fg, const char *fontlist,
+                                      double ptsize, double angle, int x, int y, const char *string)
 {
 	/* 2.0.6: valid return */
 	return gdImageStringFT (im, brect, fg, fontlist, ptsize,
@@ -112,8 +112,8 @@ BGD_DECLARE(char *) gdImageStringTTF (gdImage * im, int *brect, int fg, char *fo
 }
 
 #ifndef HAVE_LIBFREETYPE
-BGD_DECLARE(char *) gdImageStringFTEx (gdImage * im, int *brect, int fg, char *fontlist,
-                                       double ptsize, double angle, int x, int y, char *string,
+BGD_DECLARE(char *) gdImageStringFTEx (gdImage * im, int *brect, int fg, const char *fontlist,
+                                       double ptsize, double angle, int x, int y, const char *string,
                                        gdFTStringExtraPtr strex)
 {
 	(void)im;
@@ -131,7 +131,7 @@ BGD_DECLARE(char *) gdImageStringFTEx (gdImage * im, int *brect, int fg, char *f
 }
 
 BGD_DECLARE(char *) gdImageStringFT (gdImage * im, int *brect, int fg, char *fontlist,
-                                     double ptsize, double angle, int x, int y, char *string)
+                                     double ptsize, double angle, int x, int y, const char *string)
 {
 	(void)im;
 	(void)brect;
@@ -184,7 +184,7 @@ typedef struct {
 font_t;
 
 typedef struct {
-	char *fontlist;		/* key */
+	const char *fontlist;		/* key */
 	int flags;			/* key */
 	FT_Library *library;
 }
@@ -260,7 +260,7 @@ static int comp_entities(const void *e1, const void *e2)
 	return strcmp(en1->name, en2->name);
 }
 
-extern int any2eucjp (char *, char *, unsigned int);
+extern int any2eucjp (char *, const char *, unsigned int);
 
 /* Persistent font cache until explicitly cleared */
 /* Fonts can be used across multiple images */
@@ -273,7 +273,7 @@ static FT_Library library;
 #define Tcl_UniChar int
 #define TCL_UTF_MAX 3
 static int
-gdTcl_UtfToUniChar (char *str, Tcl_UniChar * chPtr)
+gdTcl_UtfToUniChar (const char *str, Tcl_UniChar * chPtr)
 /* str is the UTF8 next character pointer */
 /* chPtr is the int for the result */
 {
@@ -925,8 +925,8 @@ BGD_DECLARE(void) gdFontCacheShutdown ()
  * See also:
  *  - <gdImageString>
  */
-BGD_DECLARE(char *) gdImageStringFT (gdImage * im, int *brect, int fg, char *fontlist,
-                                     double ptsize, double angle, int x, int y, char *string)
+BGD_DECLARE(char *) gdImageStringFT (gdImage * im, int *brect, int fg, const char *fontlist,
+                                     double ptsize, double angle, int x, int y, const char *string)
 {
 	return gdImageStringFTEx (im, brect, fg, fontlist,
 	                          ptsize, angle, x, y, string, 0);
@@ -1090,8 +1090,8 @@ BGD_DECLARE(int) gdFontCacheSetup (void)
 /*    the size of the error introduced by rounding is affected by this number */
 #define METRIC_RES 300
 
-BGD_DECLARE(char *) gdImageStringFTEx (gdImage * im, int *brect, int fg, char *fontlist,
-                                       double ptsize, double angle, int x, int y, char *string,
+BGD_DECLARE(char *) gdImageStringFTEx (gdImage * im, int *brect, int fg, const char *fontlist,
+                                       double ptsize, double angle, int x, int y, const char *string,
                                        gdFTStringExtraPtr strex)
 {
 	FT_Matrix matrix;
@@ -1107,7 +1107,7 @@ BGD_DECLARE(char *) gdImageStringFTEx (gdImage * im, int *brect, int fg, char *f
 	int  i, ch;
 	font_t *font;
 	fontkey_t fontkey;
-	char *next;
+	const char *next;
 	char *tmpstr = 0;
 	uint32_t *text;
 	glyphInfo *info = NULL;

--- a/src/gdft.c
+++ b/src/gdft.c
@@ -130,7 +130,7 @@ BGD_DECLARE(char *) gdImageStringFTEx (gdImage * im, int *brect, int fg, const c
 	return "libgd was not built with FreeType font support\n";
 }
 
-BGD_DECLARE(char *) gdImageStringFT (gdImage * im, int *brect, int fg, char *fontlist,
+BGD_DECLARE(char *) gdImageStringFT (gdImage * im, int *brect, int fg, const char *fontlist,
                                      double ptsize, double angle, int x, int y, const char *string)
 {
 	(void)im;

--- a/src/gdkanji.c
+++ b/src/gdkanji.c
@@ -98,7 +98,7 @@ iconv_close (iconv_t cd)
 /* DetectKanjiCode() derived from DetectCodeType() by Ken Lunde. */
 
 static int
-DetectKanjiCode (unsigned char *str)
+DetectKanjiCode (const unsigned char *str)
 {
 	static int whatcode = ASCII;
 	int oldcode = ASCII;
@@ -334,10 +334,10 @@ han2zen (int *p1, int *p2)
 #define ustrncpy(A,B, maxsize) (strncpy((char*)(A),(const char*)(B), maxsize))
 
 static void
-do_convert (unsigned char **to_p, unsigned char **from_p, const char *code)
+do_convert (unsigned char **to_p, const unsigned char **from_p, const char *code)
 {
 	unsigned char *to = *to_p;
-	unsigned char *from = *from_p;
+	const unsigned char *from = *from_p;
 #ifdef HAVE_ICONV
 	iconv_t cd;
 	size_t from_len, to_len;
@@ -436,7 +436,7 @@ do_convert (unsigned char **to_p, unsigned char **from_p, const char *code)
 }
 
 static int
-do_check_and_conv (unsigned char *to, unsigned char *from)
+do_check_and_conv (unsigned char *to, const unsigned char *from)
 {
 	static unsigned char tmp[BUFSIZ];
 	unsigned char *tmp_p = &tmp[0];
@@ -527,7 +527,7 @@ do_check_and_conv (unsigned char *to, unsigned char *from)
 }
 
 int
-any2eucjp (unsigned char *dest, unsigned char *src, unsigned int dest_max)
+any2eucjp (unsigned char *dest, const unsigned char *src, unsigned int dest_max)
 {
 	static unsigned char tmp_dest[BUFSIZ];
 	int ret;


### PR DESCRIPTION
The following API functions now accept the font names and the text to be
printed as `const char*` rater than `char*`. This makes the functions
much more `C++` fiendly. Otherwise they are very awkward to use from `C++` being that `C++` almost always uses `const char*` and casting away the `const` causes *undefined behavior* in most cases.

```cpp
gdImageStringFT();
gdImageStringTTF();
gdImageStringFTEx();
```
**Other functions/types affected:**
```cpp
typdef struct fontkey_t;

any2eucjp();
gdTcl_UtfToUniChar();
DetectKanjiCode();
do_convert();
do_check_and_conv();
```
**Changes made to these files:**
```cpp
gd.h
gdft.c
gdkanji.c
```