### PR TITLE
Avoid accessing uninitialized buffers on short reads

### DIFF
--- a/src/gd_gif_in.c
+++ b/src/gd_gif_in.c
@@ -53,7 +53,7 @@ static int set_verbose(void)
 
 #define BitSet(byte, bit)	(((byte) & (bit)) == (bit))
 
-#define ReadOK(file, buffer, len) (gdGetBuf(buffer, len, file) > 0)
+#define ReadOK(file, buffer, len) (gdGetBuf(buffer, len, file) == len)
 
 #define LM_to_uint(a, b)	(((b)<<8)|(a))
 


### PR DESCRIPTION
llvm's memory sanitizer ("MSAN") can detect the use of uninitialized values. In cases where the provided input is very short, the strncmp for the GIF header can access uninitialized memory, which is inconsequential but can prevent the fuzzer from finding more interesting examples.