### PR TITLE
Avoid undefined behavior when reading negative integers

### DIFF
--- a/src/gd_io.c
+++ b/src/gd_io.c
@@ -130,34 +130,37 @@ int gdGetWordLSB(signed short int *result, gdIOCtx *ctx)
 int gdGetInt(int *result, gdIOCtx *ctx)
 {
 	int r;
+	unsigned int collector;
 
 	r = (ctx->getC)(ctx);
 	if(r == EOF) {
 		return 0;
 	}
 
-	*result = r << 24;
+	collector = (unsigned int) r << 24;
 
 	r = (ctx->getC)(ctx);
 	if(r == EOF) {
 		return 0;
 	}
 
-	*result += r << 16;
+	collector += r << 16;
 
 	r = (ctx->getC)(ctx);
 	if(r == EOF) {
 		return 0;
 	}
 
-	*result += r << 8;
+	collector += r << 8;
 
 	r = (ctx->getC)(ctx);
 	if(r == EOF) {
 		return 0;
 	}
 
-	*result += r;
+	collector += r;
+
+	memcpy(result, &collector, sizeof(int));
 
 	return 1;
 }


### PR DESCRIPTION
Left-shifts into signed integers which cause an overflow are undefined
behavior in C99.

Credit to OSS-Fuzz.

References:
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=5693
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=5694
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=5695