### PR TITLE
Close #435: Deprecate gdImageDashedLine()

### DIFF
--- a/src/gd.c
+++ b/src/gd.c
@@ -1541,10 +1541,23 @@ static void gdImageVLine(gdImagePtr im, int x, int y1, int y2, int col)
 }
 
 /*
-	Function: gdImageLine
-	
-	Bresenham as presented in Foley & Van Dam.
-*/
+ * Function: gdImageLine
+ *
+ * Draws a line
+ * 
+ * Uses the Bresenham algorithm as presented in Foley & Van Dam.
+ *
+ * Parameters:
+ *   im    - The image.
+ *   x1    - The x-coordinate of the start point.
+ *   y1    - The y-coordinate of the start point.
+ *   x2    - The x-coordinate of the end point.
+ *   y2    - The y-coordinate of the end point.
+ *   color - The color.
+ *
+ * See also:
+ *   - <gdImageSetStyle>
+ */
 BGD_DECLARE(void) gdImageLine (gdImagePtr im, int x1, int y1, int x2, int y2, int color)
 {
 	int dx, dy, incr1, incr2, d, x, y, xend, yend, xdirflag, ydirflag;
@@ -1713,8 +1726,26 @@ static void dashedSet (gdImagePtr im, int x, int y, int color,
 					   int *onP, int *dashStepP, int wid, int vert);
 
 /*
-	Function: gdImageDashedLine
-*/
+ * Function: gdImageDashedLine
+ *
+ * Draws a dashed line
+ *
+ * Deprecated:
+ *   This function has been deprecated as of GD 2.3.0.  Use an appropriate
+ *   combination of <gdImageLine> and <gdImageSetStyle> instead.
+ *
+ * Parameters:
+ *   im    - The image.
+ *   x1    - The x-coordinate of the start point.
+ *   y1    - The y-coordinate of the start point.
+ *   x2    - The x-coordinate of the end point.
+ *   y2    - The y-coordinate of the end point.
+ *   color - The color.
+ *
+ * See also:
+ *   - <gdImageLine>
+ *   - <gdImageSetStyle>
+ */
 BGD_DECLARE(void) gdImageDashedLine (gdImagePtr im, int x1, int y1, int x2, int y2, int color)
 {
 	int dx, dy, incr1, incr2, d, x, y, xend, yend, xdirflag, ydirflag;
@@ -1724,6 +1755,7 @@ BGD_DECLARE(void) gdImageDashedLine (gdImagePtr im, int x1, int y1, int x2, int 
 	int vert;
 	int thick = im->thick;
 
+	gd_error_ex(GD_NOTICE, "gdImageDashedLine is deprecated");
 	dx = abs (x2 - x1);
 	dy = abs (y2 - y1);
 	if (dy <= dx) {
@@ -3790,12 +3822,25 @@ static void gdImageSetAAPixelColor(gdImagePtr im, int x, int y, int color, int t
 /**
  * Function: gdImageSetStyle
  *
- * Sets the style for following drawing operations
+ * Sets the style for following drawing operations with the <gdStyled> color
  *
  * Parameters:
  *   im        - The image.
  *   style     - An array of color values.
  *   noOfPixel - The number of color values.
+ *
+ * Example:
+ *   Creating an image with a dashed line
+ *
+ *   (start code)
+ *   gdImagePtr im;
+ *   int style[] = {0x000000, 0x000000, 0x000000, 0xffffff, 0xffffff, 0xffffff};
+ *
+ *   im = gdImageCreateTrueColor(100, 20);
+ *   gdImageFilledRectangle(im, 0, 0, 99, 29, 0xffffff);
+ *   gdImageSetStyle(im, style, sizeof(style)/sizeof(int));
+ *   gdImageLine(im, 9, 10, 90, 10, gdStyled);
+ *   (end code)
  */
 BGD_DECLARE(void) gdImageSetStyle (gdImagePtr im, int *style, int noOfPixels)
 {

--- a/src/gd.h
+++ b/src/gd.h
@@ -76,7 +76,16 @@ extern "C" {
 # define BGD_STDCALL
 #endif
 
+#if defined(__GNUC__) || defined(__clang__)
+# define BGD_ATTR_DEPRECATED __attribute__((__deprecated__))
+#elif defined(_MSC_VER)
+# define BGD_ATTR_DEPRECATED __declspec(deprecated)
+#else
+# define BGD_ATTR_DEPRECATED
+#endif
+
 #define BGD_DECLARE(rt) BGD_EXPORT_DATA_PROT rt BGD_STDCALL
+#define BGD_DEPRECATED(rt) BGD_ATTR_DEPRECATED BGD_EXPORT_DATA_PROT rt BGD_STDCALL
 
 /* VS2012+ disable keyword macroizing unless _ALLOW_KEYWORD_MACROS is set
    We define inline, snprintf, and strcasecmp if they're missing 
@@ -726,7 +735,7 @@ BGD_DECLARE(void) gdImageLine (gdImagePtr im, int x1, int y1, int x2, int y2, in
 
 /* For backwards compatibility only. Use gdImageSetStyle()
    for much more flexible line drawing. */
-BGD_DECLARE(void) gdImageDashedLine (gdImagePtr im, int x1, int y1, int x2, int y2,
+BGD_DEPRECATED(void) gdImageDashedLine (gdImagePtr im, int x1, int y1, int x2, int y2,
                                      int color);
 /* Corners specified (not width and height). Upper left first, lower right
    second. */


### PR DESCRIPTION
`gdImageDashedLine()` is a legacy from GD 1, and has been superseded
by the more flexible `gdImageLine()` in combination with
`gdImageSetStyle()`.  We therefore deprecate `gdImageDashedLine()`:

* document the deprecation
* raise a compile time warning for supporting compilers
* raise a GD_NOTICE whenever the function is called