### PR TITLE
annotate.c/gdft.c: Replace strncpy with memccpy to fix -Wstringop-tru…

### DIFF
--- a/src/annotate.c
+++ b/src/annotate.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
 					fprintf(stderr, "Font maximum length is 1024, %d given\n", font_len);
 					goto badLine;
 				}
-				strncpy(font, st, font_len);
+				memcpy(font, st, font_len);
 			}
 		} else if(!strcmp(st, "align")) {
 			char *st = strtok(0, " \t\r\n");

--- a/src/gdft.c
+++ b/src/gdft.c
@@ -1809,7 +1809,7 @@ static char * font_path(char **fontpath, char *name_list)
 		gdFree(path);
 		return "could not alloc full list of fonts";
 	}
-	strncpy(fontlist, name_list, name_list_len);
+	memcpy(fontlist, name_list, name_list_len);
 	fontlist[name_list_len] = 0;
 
 	/*


### PR DESCRIPTION
…ncation.

Fixed for gcc8:
git/src/gdft.c:1699:2: error: 'strncpy' output truncated before terminating nul copying as many bytes from a string as its length [-Werror=stringop-truncation]

Signed-off-by: Robert Yang <liezhi.yang@windriver.com>