### PR TITLE
Remove trailing comma in enum list

### DIFF
--- a/src/gd_intern.h
+++ b/src/gd_intern.h
@@ -44,7 +44,7 @@
 
 typedef enum {
     HORIZONTAL,
-    VERTICAL,
+    VERTICAL
 } gdAxis;
 
 /* Convert a double to an unsigned char, rounding to the nearest


### PR DESCRIPTION
Hello,

Trailing commas in enums with the C99 are legit unless agreed otherwise with the coding style used in the given codebase.

The LLVM coding style guide doesn't use them. Neither does the default clang format tool enforce any particular trailing comma style. The Google C++ uses trailing commas. Also the git differences can be a bit nicer.

Since current code base of the libgd doesn't use trailing commas in enums, this patch syncs this to avoid possible compiler warning: comma at end of enumerator list [-Wpedantic] for C89...

Thank you.