### PR TITLE
Upgrade AX_REQUIRE_DEFINED macro file

### DIFF
--- a/m4/ax_require_defined.m4
+++ b/m4/ax_require_defined.m4
@@ -1,5 +1,5 @@
 # ===========================================================================
-#    http://www.gnu.org/software/autoconf-archive/ax_require_defined.html
+#    https://www.gnu.org/software/autoconf-archive/ax_require_defined.html
 # ===========================================================================
 #
 # SYNOPSIS
@@ -30,7 +30,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 1
+#serial 2
 
 AC_DEFUN([AX_REQUIRE_DEFINED], [dnl
   m4_ifndef([$1], [m4_fatal([macro ]$1[ is not defined; is a m4 file missing?])])


### PR DESCRIPTION
This patch bumps current file version from the Autoconf Archive from
1 to 2:
http://git.savannah.gnu.org/cgit/autoconf-archive.git/tree/m4/ax_require_defined.m4

Changes:

https links in the file comments