### PR TITLE
Remove HAVE_STRING_H

### DIFF
--- a/VMS/CONFIGURE.COM
+++ b/VMS/CONFIGURE.COM
@@ -905,9 +905,6 @@ $COPY SYS$INPUT [.SRC]CONFIG.H
 /* Define to 1 if you have the <strings.h> header file. */
 #define HAVE_STRINGS_H 1
 
-/* Define to 1 if you have the <string.h> header file. */
-#define HAVE_STRING_H 1
-
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #define HAVE_SYS_STAT_H 1
 

--- a/cmake/modules/AC_HEADER_STDC.cmake
+++ b/cmake/modules/AC_HEADER_STDC.cmake
@@ -4,7 +4,6 @@ check_include_files(dirent.h HAVE_DIRENT_H)
 check_include_files(inttypes.h HAVE_INTTYPES_H)
 check_include_files(stdint.h HAVE_STDINT_H)
 check_include_files(stdlib.h HAVE_STDLIB_H)
-check_include_files(string.h HAVE_STRING_H)
 check_include_files(strings.h HAVE_STRINGS_H)
 check_include_files(unistd.h HAVE_UNISTD_H)
 

--- a/configure.ac
+++ b/configure.ac
@@ -63,7 +63,6 @@ AC_CHECK_HEADERS_ONCE(m4_flatten([
 	inttypes.h
 	stdint.h
 	stdlib.h
-	string.h
 	strings.h
 	unistd.h
 	sys/stat.h

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -81,9 +81,6 @@
 /* Define to 1 if you have the <strings.h> header file. */
 #cmakedefine HAVE_STRINGS_H
 
-/* Define to 1 if you have the <string.h> header file. */
-#cmakedefine HAVE_STRING_H
-
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #cmakedefine HAVE_SYS_STAT_H
 

--- a/src/webpng.c
+++ b/src/webpng.c
@@ -9,9 +9,7 @@
 #ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif
-#ifdef HAVE_STRING_H
 #include <string.h>
-#endif
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif


### PR DESCRIPTION
The C89 and later standard defines the `<string.h>` header as part of
the standard headers [1] and on current systems it is always present
and the `HAVE_STRING_H` symbol can be removed.

Also Autoconf suggests doing this and relying on C89 or above [2] and [3].

[1] https://port70.net/~nsz/c/c89/c89-draft.html#4.1.2
[2] http://git.savannah.gnu.org/cgit/autoconf.git/tree/lib/autoconf/headers.m4
[3] https://www.gnu.org/software/autoconf/manual/autoconf-2.69/autoconf.html