### PR TITLE
Remove AC_FUNC_VPRINTF

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -93,7 +93,6 @@ AC_CHECK_HEADERS(iconv.h,
 #AC_FUNC_ERROR_AT_LINE
 #AC_FUNC_MALLOC
 #AC_FUNC_REALLOC
-#AC_FUNC_VPRINTF
 #AC_CHECK_FUNCS([floor memset sqrt strchr strdup strtol])
 
 dnl do we need to specify -lm explicitly?


### PR DESCRIPTION
Autoconf 2.59d (released in 2006) [1] started promoting several macros
as not relevant for newer systems anymore, including the `AC_FUNC_VPRINTF`.

This macro checks for presence of the C `vprint` function otherwise
checks for the presence of the `_doprnt` function. This check was
relevant on very old systems and today can be omitted since it should
be well supported by now. [2]

Also libgd doesn't use the `HAVE_VPRINTF` or `HAVE_DOPRNT` symbols.

Refs:
[1] http://git.savannah.gnu.org/cgit/autoconf.git/tree/NEWS
[2] https://www.gnu.org/software/autoconf/manual/autoconf-2.69/autoconf.html