### PR TITLE
Fix 479: Try to make gdMalloc() return 16-byte aligned memory

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,6 +95,9 @@ AC_CHECK_HEADERS(iconv.h,
 dnl do we need to specify -lm explicitly?
 AC_CHECK_FUNC(sin,,[AC_CHECK_LIB(m,sin)])
 
+dnl No need to check for posix_memalign if aligned_alloc works.
+AC_CHECK_FUNCS([aligned_alloc posix_memalign], [break])
+
 AX_PTHREAD()
 AX_OPENMP()
 

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -6,6 +6,9 @@
 /* Whether to support gd image formats */
 #define ENABLE_GD_FORMATS @ENABLE_GD_FORMATS@
 
+/* Define to 1 if you have the `aligned_alloc' function. */
+#cmakedefine HAVE_ALIGNED_ALLOC
+
 /* Define to 1 if you have the <dirent.h> header file. */
 #cmakedefine HAVE_DIRENT_H
 
@@ -66,6 +69,9 @@
 /* Define if OpenMP is enabled */
 #cmakedefine HAVE_OPENMP
 
+/* Define to 1 if you have the `posix_memalign' function. */
+#cmakedefine HAVE_POSIX_MEMALIGN
+
 /* Define if you have POSIX threads libraries and header files. */
 #cmakedefine HAVE_PTHREAD
 
@@ -75,8 +81,14 @@
 /* Define to 1 if you have the <stdint.h> header file. */
 #cmakedefine HAVE_STDINT_H
 
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H
+
 /* Define to 1 if you have the <strings.h> header file. */
 #cmakedefine HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#cmakedefine HAVE_STRING_H
 
 /* Define to 1 if you have the <sys/stat.h> header file. */
 #cmakedefine HAVE_SYS_STAT_H

--- a/src/gdhelpers.c
+++ b/src/gdhelpers.c
@@ -69,10 +69,26 @@ void * gdCalloc (size_t nmemb, size_t size)
 	return calloc (nmemb, size);
 }
 
+#ifdef HAVE_ALIGNED_ALLOC
+# define USE_ALIGNED_ALLOC 1
+#elif defined HAVE_POSIX_MEMALIGN
+# define USE_ALIGNED_ALLOC 1
+static void *
+aligned_alloc (size_t alignment, size_t size)
+{
+	void *p;
+	return posix_memalign (&p, 16, size) == 0 ? p : 0;
+}
+#endif
+
 void *
 gdMalloc (size_t size)
 {
+#if defined HAVE_LIBIMAGEQUANT && defined USE_ALIGNED_ALLOC
+	return aligned_alloc (16, size);
+#else
 	return malloc (size);
+#endif
 }
 
 void *


### PR DESCRIPTION
This is necessary if we're using libimagequant.