### PR TITLE
Compute average in gdGuessBackgroundColorFromCorners properly

### DIFF
--- a/src/gd_crop.c
+++ b/src/gd_crop.c
@@ -303,10 +303,10 @@ static int gdGuessBackgroundColorFromCorners(gdImagePtr im, int *color)
 	} else {
 		register int r,b,g,a;
 
-		r = (int)(0.5f + (gdImageRed(im, tl) + gdImageRed(im, tr) + gdImageRed(im, bl) + gdImageRed(im, br)) / 4);
-		g = (int)(0.5f + (gdImageGreen(im, tl) + gdImageGreen(im, tr) + gdImageGreen(im, bl) + gdImageGreen(im, br)) / 4);
-		b = (int)(0.5f + (gdImageBlue(im, tl) + gdImageBlue(im, tr) + gdImageBlue(im, bl) + gdImageBlue(im, br)) / 4);
-		a = (int)(0.5f + (gdImageAlpha(im, tl) + gdImageAlpha(im, tr) + gdImageAlpha(im, bl) + gdImageAlpha(im, br)) / 4);
+		r = (2 + gdImageRed(im, tl) + gdImageRed(im, tr) + gdImageRed(im, bl) + gdImageRed(im, br)) / 4;
+		g = (2 + gdImageGreen(im, tl) + gdImageGreen(im, tr) + gdImageGreen(im, bl) + gdImageGreen(im, br)) / 4;
+		b = (2 + gdImageBlue(im, tl) + gdImageBlue(im, tr) + gdImageBlue(im, bl) + gdImageBlue(im, br)) / 4;
+		a = (2 + gdImageAlpha(im, tl) + gdImageAlpha(im, tr) + gdImageAlpha(im, bl) + gdImageAlpha(im, br)) / 4;
 		*color = gdImageColorClosestAlpha(im, r, g, b, a);
 		return 0;
 	}


### PR DESCRIPTION
Coverity scanning finds following error in libgd:
```
Error: UNINTENDED_INTEGER_DIVISION:
libgd-2.2.5/src/gd_crop.c:302: integer_division: Dividing integer expressions "(im->trueColor ? (tl & 0xff0000) >> 16 : im->red[tl]) + (im->trueColor ? (tr & 0xff0000) >> 16 : im->red[tr]) + (im->trueColor ? (bl & 0xff0000) >> 16 : im->red[bl]) + (im->trueColor ? (br & 0xff0000) >> 16 : im->red[br])" and "4", and then converting the integer quotient to type "float". Any remainder, or fractional part of the quotient, is ignored.
libgd-2.2.5/src/gd_crop.c:302: rounding_remediation: For the rounding operation to work as intended, change or cast either division operand to type "float".
#  300|   		register int r,b,g,a;
#  301|   
#  302|-> 		r = (int)(0.5f + (gdImageRed(im, tl) + gdImageRed(im, tr) + gdImageRed(im, bl) + gdImageRed(im, br)) / 4);
#  303|   		g = (int)(0.5f + (gdImageGreen(im, tl) + gdImageGreen(im, tr) + gdImageGreen(im, bl) + gdImageGreen(im, br)) / 4);
#  304|   		b = (int)(0.5f + (gdImageBlue(im, tl) + gdImageBlue(im, tr) + gdImageBlue(im, bl) + gdImageBlue(im, br)) / 4);
```

This PR aims to fix this and compute the color average properly.
