### PR TITLE
add stub ABI funcs when formats are disabled #345

### DIFF
--- a/src/gd_jpeg.c
+++ b/src/gd_jpeg.c
@@ -1192,4 +1192,63 @@ void jpeg_gdIOCtx_dest(j_compress_ptr cinfo, gdIOCtx *outfile)
 	dest->outfile = outfile;
 }
 
+#else /* !HAVE_LIBJPEG */
+
+static void _noJpegError(void)
+{
+	gd_error("JPEG image support has been disabled\n");
+}
+
+BGD_DECLARE(void) gdImageJpeg(gdImagePtr im, FILE *outFile, int quality)
+{
+	_noJpegError();
+}
+
+BGD_DECLARE(void *) gdImageJpegPtr(gdImagePtr im, int *size, int quality)
+{
+	_noJpegError();
+	return NULL;
+}
+
+BGD_DECLARE(void) gdImageJpegCtx(gdImagePtr im, gdIOCtx *outfile, int quality)
+{
+	_noJpegError();
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromJpeg(FILE *inFile)
+{
+	_noJpegError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromJpegEx(FILE *inFile, int ignore_warning)
+{
+	_noJpegError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromJpegPtr(int size, void *data)
+{
+	_noJpegError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromJpegPtrEx(int size, void *data, int ignore_warning)
+{
+	_noJpegError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromJpegCtx(gdIOCtx *infile)
+{
+	_noJpegError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromJpegCtxEx(gdIOCtx *infile, int ignore_warning)
+{
+	_noJpegError();
+	return NULL;
+}
+
 #endif /* HAVE_LIBJPEG */

--- a/src/gd_png.c
+++ b/src/gd_png.c
@@ -1089,5 +1089,57 @@ bail:
 	return ret;
 }
 
+#else /* !HAVE_LIBPNG */
+
+static void _noPngError(void)
+{
+	gd_error("PNG image support has been disabled\n");
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromPng (FILE * inFile)
+{
+	_noPngError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromPngPtr (int size, void *data)
+{
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromPngCtx (gdIOCtx * infile)
+{
+	return NULL;
+}
+
+BGD_DECLARE(void) gdImagePngEx (gdImagePtr im, FILE * outFile, int level)
+{
+	_noPngError();
+}
+
+BGD_DECLARE(void) gdImagePng (gdImagePtr im, FILE * outFile)
+{
+	_noPngError();
+}
+
+BGD_DECLARE(void *) gdImagePngPtr (gdImagePtr im, int *size)
+{
+	return NULL;
+}
+
+BGD_DECLARE(void *) gdImagePngPtrEx (gdImagePtr im, int *size, int level)
+{
+	return NULL;
+}
+
+BGD_DECLARE(void) gdImagePngCtx (gdImagePtr im, gdIOCtx * outfile)
+{
+	_noPngError();
+}
+
+BGD_DECLARE(void) gdImagePngCtxEx (gdImagePtr im, gdIOCtx * outfile, int level)
+{
+	_noPngError();
+}
 
 #endif /* HAVE_LIBPNG */

--- a/src/gd_tiff.c
+++ b/src/gd_tiff.c
@@ -1069,4 +1069,45 @@ BGD_DECLARE(void *) gdImageTiffPtr(gdImagePtr im, int *size)
 	return rv;
 }
 
+#else
+
+static void _noTiffError(void)
+{
+	gd_error("TIFF image support has been disabled\n");
+}
+
+BGD_DECLARE(void) gdImageTiffCtx(gdImagePtr image, gdIOCtx *out)
+{
+	_noTiffError();
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromTiffCtx(gdIOCtx *infile)
+{
+	_noTiffError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromTiff(FILE *inFile)
+{
+	_noTiffError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromTiffPtr(int size, void *data)
+{
+	_noTiffError();
+	return NULL;
+}
+
+BGD_DECLARE(void) gdImageTiff(gdImagePtr im, FILE *outFile)
+{
+	_noTiffError();
+}
+
+BGD_DECLARE(void *) gdImageTiffPtr(gdImagePtr im, int *size)
+{
+	_noTiffError();
+	return NULL;
+}
+
 #endif

--- a/src/gd_webp.c
+++ b/src/gd_webp.c
@@ -9,7 +9,6 @@
 #endif /* HAVE_CONFIG_H */
 
 
-#ifdef HAVE_LIBWEBP
 #include <stdio.h>
 #include <math.h>
 #include <string.h>
@@ -17,6 +16,8 @@
 #include "gd.h"
 #include "gd_errors.h"
 #include "gdhelpers.h"
+
+#ifdef HAVE_LIBWEBP
 #include "webp/decode.h"
 #include "webp/encode.h"
 
@@ -360,4 +361,57 @@ BGD_DECLARE(void *) gdImageWebpPtrEx (gdImagePtr im, int *size, int quality)
 	out->gd_free(out);
 	return rv;
 }
+
+#else /* !HAVE_LIBWEBP */
+
+static void _noWebpError(void)
+{
+	gd_error("WEBP image support has been disabled\n");
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromWebp (FILE * inFile)
+{
+	_noWebpError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromWebpPtr (int size, void *data)
+{
+	_noWebpError();
+	return NULL;
+}
+
+BGD_DECLARE(gdImagePtr) gdImageCreateFromWebpCtx (gdIOCtx * infile)
+{
+	_noWebpError();
+	return NULL;
+}
+
+BGD_DECLARE(void) gdImageWebpCtx (gdImagePtr im, gdIOCtx * outfile, int quality)
+{
+	_noWebpError();
+}
+
+BGD_DECLARE(void) gdImageWebpEx (gdImagePtr im, FILE * outFile, int quality)
+{
+	_noWebpError();
+}
+
+BGD_DECLARE(void) gdImageWebp (gdImagePtr im, FILE * outFile)
+{
+	_noWebpError();
+}
+
+BGD_DECLARE(void *) gdImageWebpPtr (gdImagePtr im, int *size)
+{
+	_noWebpError();
+	return NULL;
+}
+
+BGD_DECLARE(void *) gdImageWebpPtrEx (gdImagePtr im, int *size, int quality)
+{
+	_noWebpError();
+	return NULL;
+}
+
 #endif /* HAVE_LIBWEBP */

--- a/src/gdpp.cxx
+++ b/src/gdpp.cxx
@@ -39,11 +39,10 @@ namespace GD
 		   0x89 0x50 0x4E 0x47 0x0D 0x0A 0x1A 0x0A
 		   == .PNG\r\n.\n
 		*/
-#ifdef HAVE_LIBPNG
 		case 0x89: // PNG
 			rtn = CreateFromPng(in);
 			break;
-#endif
+
 		/* GIF
 			0x47 0x49 0x46
 		*/
@@ -121,7 +120,6 @@ namespace GD
 		bool rtn;
 		switch (in.peek())
 			{
-#ifdef HAVE_LIBPNG
 		/* PNG
 		The first eight bytes of a PNG file always contain the following (decimal) values:
 		   0x89 0x50 0x4E 0x47 0x0D 0x0A 0x1A 0x0A
@@ -130,7 +128,6 @@ namespace GD
 		case 0x89: // PNG
 			rtn = CreateFromPng(in);
 			break;
-#endif
 
 		/* GIF
 			0x47 0x49 0x46
@@ -192,7 +189,6 @@ namespace GD
 		switch (((unsigned char * )data)[0])
 			{
 
-#ifdef HAVE_LIBPNG
 		/* PNG
 		The first eight bytes of a PNG file always contain the following (decimal) values:
 		   0x89 0x50 0x4E 0x47 0x0D 0x0A 0x1A 0x0A
@@ -201,7 +197,7 @@ namespace GD
 		case 0x89: // PNG
 			rtn = CreateFromPng(size, data);
 			break;
-#endif
+
 		/* GIF
 			0x47 0x49 0x46
 		*/

--- a/src/gdpp.h
+++ b/src/gdpp.h
@@ -291,7 +291,7 @@ public:
 		:im(0) {
 		CreateFrom(size, data);
 	}
-#ifdef HAVE_LIBPNG
+
 	/** Construct an image by reading from \p in.
 		The tag is an empty struct which simply tells the compiler which image read function to use.
 		e.g. GD::Image img(input, GD::Png_tag()); // read a png file from input
@@ -329,7 +329,6 @@ public:
 		:im(0) {
 		CreateFromPng(size, data);
 	}
-#endif
 
 	/** Construct an image by reading from \p in.
 		The tag is an empty struct which simply tells the compiler which image read function to use.
@@ -607,7 +606,6 @@ public:
 	/// Read an image from a memory block, after determining the image format
 	bool CreateFrom(int size, void * data);
 
-#ifdef HAVE_LIBPNG
 	// Png
 	bool CreateFromPng(FILE * in) {
 		clear();
@@ -626,7 +624,6 @@ public:
 		istreamIOCtx _in_ctx(in);
 		return ((im = gdImageCreateFromPngCtx( & _in_ctx)) != 0);
 	}
-#endif
 
 	// Gif
 	bool CreateFromGif(FILE * in) {

--- a/src/gdtestft.c
+++ b/src/gdtestft.c
@@ -32,7 +32,6 @@ main (int argc, char *argv[])
 	int brect[8];
 	int x, y, sx, sy;
 	char *err;
-	FILE *out;
 #ifdef JISX0208
 	char *s = "Hello. ‚±‚ñ‚É‚¿‚Í Qyjpqg,";	/* String to draw. */
 #else
@@ -147,7 +146,7 @@ main (int argc, char *argv[])
 	/* TBB: Write img to test/fttest.jpg or test/fttest.png */
 	if (im->trueColor) {
 #ifdef HAVE_LIBJPEG
-		out = fopen ("test/fttest.jpg", "wb");
+		FILE *out = fopen ("test/fttest.jpg", "wb");
 		if (!out) {
 			fprintf(stderr, "Can't create test/fttest.jpg\n");
 			exit (1);
@@ -161,7 +160,7 @@ main (int argc, char *argv[])
 #endif
 	} else {
 #ifdef HAVE_LIBPNG
-		out = fopen ("test/fttest.png", "wb");
+		FILE *out = fopen ("test/fttest.png", "wb");
 		if (!out) {
 			fprintf(stderr, "Can't create test/fttest.png\n");
 			exit (1);

--- a/tests/gdtest/gdtest.c
+++ b/tests/gdtest/gdtest.c
@@ -40,7 +40,6 @@ void gdSilence(int priority, const char *format, va_list args)
 	(void)args;
 }
 
-#ifdef HAVE_LIBPNG
 gdImagePtr gdTestImageFromPng(const char *filename)
 {
 	gdImagePtr image;
@@ -65,7 +64,6 @@ gdImagePtr gdTestImageFromPng(const char *filename)
 	fclose(fp);
 	return image;
 }
-#endif
 
 static char *tmpdir_base;
 
@@ -503,7 +501,6 @@ unsigned int gdMaxPixelDiff(gdImagePtr a, gdImagePtr b)
     return diff;
 }
 
-#ifdef HAVE_LIBPNG
 int gdTestImageCompareToImage(const char* file, unsigned int line, const char* message,
                               gdImagePtr expected, gdImagePtr actual)
 {
@@ -583,9 +580,7 @@ fail:
 	}
 	return 1;
 }
-#endif
 
-#ifdef HAVE_LIBPNG
 int gdTestImageCompareToFile(const char* file, unsigned int line, const char* message,
                              const char *expected_file, gdImagePtr actual)
 {
@@ -603,7 +598,6 @@ int gdTestImageCompareToFile(const char* file, unsigned int line, const char* me
 	}
 	return res;
 }
-#endif
 
 static int failureCount = 0;
 


### PR DESCRIPTION
We do this for some funcs already, so add jpeg/png/tiff/liq/webp
stubs too.  This keeps our ABI stable and lets code do runtime
detection instead.