### PR TITLE
Fix #501: Uninitialized read in gdImageCreateFromXbm (CVE-2019-11038)

### DIFF
--- a/src/gd_xbm.c
+++ b/src/gd_xbm.c
@@ -169,7 +169,11 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromXbm(FILE * fd)
 			}
 			h[3] = ch;
 		}
-		sscanf(h, "%x", &b);
+		if (sscanf(h, "%x", &b) != 1) {
+			gd_error("invalid XBM");
+			gdImageDestroy(im);
+			return 0;
+		}
 		for (bit = 1; bit <= max_bit; bit = bit << 1) {
 			gdImageSetPixel(im, x++, y, (b & bit) ? 1 : 0);
 			if (x == im->sx) {


### PR DESCRIPTION
Bug-Debian-Security: https://security-tracker.debian.org/tracker/CVE-2019-11038
Bug-Debian: https://bugs.debian.org/929821
Bug: https://github.com/libgd/libgd/issues/501

We have to ensure that `sscanf()` does indeed read a hex value here,
and bail out otherwise.

Original patch by Christoph M. Becker <cmbecker69@gmx.de> for PHP libgd ext.
https://git.php.net/?p=php-src.git;a=commit;h=ed6dee9a198c904ad5e03113e58a2d2c200f5184