### PR TITLE
Update source download url and bug report url in README.TESTING

### DIFF
--- a/docs/README.TESTING
+++ b/docs/README.TESTING
@@ -40,11 +40,11 @@ If you use a packaged version of the GD Library (installed from RPM, deb or
 ports, gentoo packages or any other packages format or distribution), please try
 to run the tests using the source releases available at:
 
-http://www.libgd.org/Downloads
+http://github.com/libgd/libgd/release
 
 If the tests fail using our source release, please report a bug here:
 
-http://bugs.libgd.org
+http://github.com/libgd/libgd/issues
 
 You can attach the two files available in:
 

--- a/docs/README.TESTING
+++ b/docs/README.TESTING
@@ -40,11 +40,11 @@ If you use a packaged version of the GD Library (installed from RPM, deb or
 ports, gentoo packages or any other packages format or distribution), please try
 to run the tests using the source releases available at:
 
-http://github.com/libgd/libgd/release
+https://github.com/libgd/libgd/releases
 
 If the tests fail using our source release, please report a bug here:
 
-http://github.com/libgd/libgd/issues
+https://github.com/libgd/libgd/issues
 
 You can attach the two files available in:
 


### PR DESCRIPTION
It seems that the old urls can't not be found.