### PR TITLE
fixed cmake failed with generators "Visual Studio XX" under windows

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -33,7 +33,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 int	opterr = 1,		/* if error message should be printed */
 	optind = 1,		/* index into parent argv vector */


### PR DESCRIPTION
unistd.h (included in src/getopt.c) can't not be found definitely in win. And it is also unnessary for building libgd both by cmake and automake in Linux.