### PR TITLE
fixed optxxx var undefined in src/webpng.c under MSVC

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -33,7 +33,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 int	opterr = 1,		/* if error message should be printed */
 	optind = 1,		/* index into parent argv vector */

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -1,0 +1,20 @@
+#ifndef GETOPT_H
+#define GETOPT_H 1
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern int opterr;
+extern int optind;
+extern int optopt;
+extern int optreset;
+extern char *optarg;
+
+int getopt(int nargc, char * const nargv[], const char *ostr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/webpng.c
+++ b/src/webpng.c
@@ -2,6 +2,10 @@
 #include "config.h"
 #endif
 
+#ifdef WIN32
+#include "getopt.h"
+#endif
+
 /* Bring in standard I/O and string manipulation functions */
 #include <stdarg.h>
 #include <errno.h>


### PR DESCRIPTION
`unistd.h` can not included by src/webpng.c under MSVC. So optind opterr and related var are unavaible.