### PR TITLE
windows/msys/run_tests.sh: skip fontconfig and xpm test cases

### DIFF
--- a/windows/msys/run_tests.sh
+++ b/windows/msys/run_tests.sh
@@ -38,7 +38,7 @@ echo "Running tests:"
 count=0
 failures=0
 compile_failures=0
-for test in `find . -name \*.c | grep -v '^./gdtest'`; do
+for test in `find . \( -path ./xpm -o -path ./fontconfig \) -prune -o -type f -name \*.c | grep -v '^./gdtest'`; do
     count=`expr $count + 1`
 
     exe=${test%.c}.exe


### PR DESCRIPTION
libxpm and libfontconfig are unavaible in windows. So skip fontconfig and xpm test cases by excluding their test path