### PR TITLE
tests/gdtest/gdtest.c: Update gdtest to support msys

### DIFF
--- a/tests/gdtest/gdtest.c
+++ b/tests/gdtest/gdtest.c
@@ -33,6 +33,10 @@
 #define HAVE_SYS_STAT_H
 #endif
 
+#ifndef GDTEST_TOP_DIR
+#include "test_config.h"
+#endif
+
 #include "gd.h"
 
 #include "gdtest.h"

--- a/tests/gdtest/gdtest.c
+++ b/tests/gdtest/gdtest.c
@@ -23,14 +23,12 @@
 #include <sys/types.h>
 #endif
 
-#if defined(_WIN32) && !defined(_MINGW32_)
-# include "readdir.h"
-#endif
-
 #ifdef _WIN32
-#include<errno.h>
+#include "readdir.h"
+#include <errno.h>
 #endif
 
+/*test_config.h is created by run_test.sh and GDTEST_TOP_DIR is never defined in msys*/
 #ifndef GDTEST_TOP_DIR
 #include "test_config.h"
 #endif

--- a/tests/gdtest/gdtest.c
+++ b/tests/gdtest/gdtest.c
@@ -15,6 +15,11 @@
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
 #endif
+
+#ifndef HAVE_SYS_STAT_H
+#define HAVE_SYS_STAT_H
+#endif
+
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
@@ -29,8 +34,6 @@
 #ifdef _WIN32
 #include<windows.h>
 #include<errno.h>
-#else
-#define HAVE_SYS_STAT_H
 #endif
 
 #ifndef GDTEST_TOP_DIR

--- a/tests/gdtest/gdtest.c
+++ b/tests/gdtest/gdtest.c
@@ -1,4 +1,6 @@
+#ifdef HAVE_CONFIG_H
 #include <config.h>
+#endif
 #include <assert.h>
 #include <setjmp.h>
 #include <stdlib.h>
@@ -20,8 +22,15 @@
 #include <sys/types.h>
 #endif
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(_MINGW32_)
 # include "readdir.h"
+#endif
+
+#ifdef _WIN32
+#include<windows.h>
+#include<errno.h>
+#else
+#define HAVE_SYS_STAT_H
 #endif
 
 #include "gd.h"

--- a/tests/gdtest/gdtest.c
+++ b/tests/gdtest/gdtest.c
@@ -16,10 +16,6 @@
 #include <unistd.h>
 #endif
 
-#ifndef HAVE_SYS_STAT_H
-#define HAVE_SYS_STAT_H
-#endif
-
 #ifdef HAVE_SYS_STAT_H
 #include <sys/stat.h>
 #endif
@@ -32,7 +28,6 @@
 #endif
 
 #ifdef _WIN32
-#include<windows.h>
 #include<errno.h>
 #endif
 

--- a/windows/msys/run_tests.sh
+++ b/windows/msys/run_tests.sh
@@ -38,7 +38,7 @@ echo "Running tests:"
 count=0
 failures=0
 compile_failures=0
-for test in `find . \( -path ./xpm -o -path ./fontconfig \) -prune -o -type f -name \*.c | grep -v '^./gdtest'`; do
+for test in `find . \( -path ./xpm -o -path ./fontconfig \) -prune -o -type f -name \*.c -print | grep -v '^./gdtest'`; do
     count=`expr $count + 1`
 
     exe=${test%.c}.exe

--- a/windows/msys/run_tests.sh
+++ b/windows/msys/run_tests.sh
@@ -38,7 +38,7 @@ echo "Running tests:"
 count=0
 failures=0
 compile_failures=0
-for test in `find . \( -path ./xpm -o -path ./fontconfig \) -prune -o -type f -name \*.c -print | grep -v '^./gdtest'`; do
+for test in `find . \( -path ./xpm -o -path ./fontconfig \) -prune -o -type f -name \*.c | grep -v '^./gdtest'`; do
     count=`expr $count + 1`
 
     exe=${test%.c}.exe


### PR DESCRIPTION
Update tests/gdtest/gdtest.c to support windows msys include:
1. `if (errno != EEXIST)` error
2.  `config.h` not found
3. `GDTEST_TOP_DIR` not found