### PR TITLE
Fix GD build with -D SIGNED_COMPARE_SLOW

### DIFF
--- a/src/gd_gif_out.c
+++ b/src/gd_gif_out.c
@@ -1404,7 +1404,7 @@ static void compress(int init_bits, gdIOCtxPtr outfile, gdImagePtr im, GifCtx *c
 	output((code_int)ctx->ClearCode, ctx);
 
 #ifdef SIGNED_COMPARE_SLOW
-	while((c = GIFNextPixel(im)) != (unsigned) EOF) {
+	while((c = GIFNextPixel(im, ctx)) != (unsigned) EOF) {
 #else /* SIGNED_COMPARE_SLOW */
 	while((c = GIFNextPixel(im, ctx)) != EOF) {
 #endif /* SIGNED_COMPARE_SLOW */


### PR DESCRIPTION
Apparently, this has not been tested for a long time, and might be a
refactoring relict.  Anyhow, we have to pass the context to
`GIFNextPixel` as well.

This issue has been reported by Kleber Tarcísio.