### PR TITLE
src/CMakeLists.txt: drop header files in add_library

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,8 @@
 SET (LIBGD_SRC_FILES
-	bmp.h
 	gd.c
-	gd.h
 	gd_bmp.c
 	gd_color.c
-	gd_color.h
 	gd_color_map.c
-	gd_color_map.h
 	gd_color_match.c
 	gd_crop.c
 	gd_filename.c
@@ -15,25 +11,20 @@ SET (LIBGD_SRC_FILES
 	gd_gd2.c
 	gd_gif_in.c
 	gd_gif_out.c
-	gd_intern.h
 	gd_interpolation.c
 	gd_io.c
-	gd_io.h
 	gd_io_dp.c
 	gd_io_file.c
 	gd_io_ss.c
 	gd_io_stream.cxx
-	gd_io_stream.h
 	gd_jpeg.c
 	gd_matrix.c
 	gd_nnquant.c
-	gd_nnquant.h
 	gd_png.c
 	gd_rotate.c
 	gd_security.c
 	gd_ss.c
 	gd_tga.c
-	gd_tga.h
 	gd_tiff.c
 	gd_topal.c
 	gd_transform.c
@@ -42,30 +33,19 @@ SET (LIBGD_SRC_FILES
 	gd_webp.c
 	gd_xbm.c
 	gdcache.c
-	gdcache.h
 	gdfontg.c
-	gdfontg.h
 	gdfontl.c
-	gdfontl.h
 	gdfontmb.c
-	gdfontmb.h
 	gdfonts.c
-	gdfonts.h
 	gdfontt.c
-	gdfontt.h
 	gdft.c
 	gdfx.c
-	gdfx.h
 	gdhelpers.c
-	gdhelpers.h
 	gdkanji.c
 	gdpp.cxx
-	gdpp.h
 	gdtables.c
 	gdxpm.c
-	jisx0208.h
 	wbmp.c
-	wbmp.h
 )
 
 # Static library just for utility programs.


### PR DESCRIPTION
Header file will expend in source file in precompile stage. So header file is not necessary for `add_library` in CMakeLists.txt