### PR TITLE
remove or change testcase

### DIFF
--- a/src/gdcache.c
+++ b/src/gdcache.c
@@ -192,7 +192,7 @@ static void cacheRelease(void *map)
 	gdFree((char *)map);
 }
 
-int main(char *argv[], int argc)
+int main(int argc, char **argv)
 {
 	gdCache_head_t *cacheTable;
 	int elem, key;


### PR DESCRIPTION
Hi everyone, 

I believe when this test case was created the main signature was different from now.

I think this test case has not been used for a long time, but if one day someone tries to execute, then a compilation error will occur because of the signature of the main (char, int) method should be main (int, char). or just main ().

Error message:
gdcache.c:200:5: error: first argument of ‘main’ should be ‘int’

I agree that this is not critical, but I believe that to increase code quality this should be fixed.

Thank's for your time.