### PR TITLE
cmake: remove required host includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,6 @@ else (USE_EXT_GD)
 	GV_LT(VERSION GDLIB_LIB_VERSION)
 	MESSAGE(STATUS "gd shared lib version ${GDLIB_LIB_SOVERSION} (${GDLIB_LIB_VERSION})")
 
-	SET(CMAKE_REQUIRED_INCLUDES "/usr/include" "/usr/local/include")
-
 	include(CheckIncludeFiles)
 	include(CheckIncludeFile)
 


### PR DESCRIPTION
This breaks cross-compilation. More info:
https://github.com/openwrt/packages/pull/10079