### PR TITLE
gdlib.pc: use prefixes for pkgconfig file

### DIFF
--- a/config/gdlib.pc.cmake
+++ b/config/gdlib.pc.cmake
@@ -1,5 +1,7 @@
-libdir=@CMAKE_INSTALL_FULL_LIBDIR@
-includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
 
 Name: gd
 Description: GD graphics library


### PR DESCRIPTION
This allows the pkgconfig file to be properly used in cross compile
scenarios by overriding the prefix. Otherwise, it points to host
libraries.

Signed-off-by: Rosen Penev <rosenp@gmail.com>