### PR TITLE
src/config.h.cmake: use #cmakedefine01 for ENABLE_GD_FORMATS

### DIFF
--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -4,7 +4,7 @@
 #cmakedefine BGDWIN32
 
 /* Whether to support gd image formats */
-#define ENABLE_GD_FORMATS @ENABLE_GD_FORMATS@
+#cmakedefine01 ENABLE_GD_FORMATS
 
 /* Define to 1 if you have the <dirent.h> header file. */
 #cmakedefine HAVE_DIRENT_H


### PR DESCRIPTION
Although we have [docs/README.CMAKE](https://github.com/libgd/libgd/blob/master/docs/README.CMAKE) describ the avaiable options are ENABLE_XXX=1/0, some users are familar with ENABLE_XXX=ON/OF.  If ENABLE_GD_FORMATS=ON is used, it will result that GD formats is not enabled actually.