### PR TITLE
tests/gdimageline/gdimageline_bug5: add im null judgement

### DIFF
--- a/tests/gdimageline/gdimageline_bug5.c
+++ b/tests/gdimageline/gdimageline_bug5.c
@@ -10,7 +10,13 @@ int main() {
 	/* FILE *pngout; */
 	int black, white;
 
+	/* If the data seg size is less than 195000,
+	 * gdImageCrateTrueColor will return NULL.
+	 * See https://github.com/libgd/libgd/issues/621 */
 	im = gdImageCreateTrueColor(63318, 771);
+	if (gdTestAssert(im != NULL) == 0) {
+		return gdNumFailures();
+	}
 
 	/* Allocate the color white (red, green and blue all maximum). */
 	white = gdImageColorAllocate(im, 255, 255, 255);

--- a/tests/gdimageline/gdimageline_bug5.c
+++ b/tests/gdimageline/gdimageline_bug5.c
@@ -14,7 +14,7 @@ int main() {
 	 * gdImageCrateTrueColor will return NULL.
 	 * See https://github.com/libgd/libgd/issues/621 */
 	im = gdImageCreateTrueColor(63318, 771);
-	if (gdTestAssert(im != NULL) == 0) {
+	if (gdTestAssertMsg(im != NULL, "gdImageCreateTrueColor() returns NULL\n") == 0) {
 		return gdNumFailures();
 	}
 


### PR DESCRIPTION
Reference to #621. `gdimageline_bug5` runs with segment fault on AIX, which is caused by the data segment size is less than 195000.