### PR TITLE
Retain transparency when using gdImageCopyResized on palette PNG

### DIFF
--- a/src/gd.c
+++ b/src/gd.c
@@ -3277,6 +3277,14 @@ BGD_DECLARE(void) gdImageCopyResized (gdImagePtr dst, gdImagePtr src, int dstX, 
 					c = gdImageGetPixel (src, x, y);
 					/* Added 7/24/95: support transparent copies */
 					if (gdImageGetTransparent (src) == c) {
+						if (colorMap[c] == (-1)) {
+							colorMap[c] = gdImageColorResolveAlpha(dst,
+																	gdImageRed (src, c),
+																	gdImageGreen(src, c),
+																	gdImageBlue (src, c),
+																	gdAlphaTransparent);
+							gdImageColorTransparent(dst, c);
+						}
 						tox += stx[x - srcX];
 						continue;
 					}

--- a/tests/gdimagecopyresized/CMakeLists.txt
+++ b/tests/gdimagecopyresized/CMakeLists.txt
@@ -1,6 +1,7 @@
 IF(PNG_FOUND)
 LIST(APPEND TESTS_FILES
 	gdimagecopyresized
+	github_bug_00638_transparent_png
 )
 ENDIF(PNG_FOUND)
 

--- a/tests/gdimagecopyresized/Makemodule.am
+++ b/tests/gdimagecopyresized/Makemodule.am
@@ -1,6 +1,7 @@
 if HAVE_LIBPNG
 libgd_test_programs += \
 	gdimagecopyresized/gdimagecopyresized
+	gdimagecopyresized/github_bug_00638_transparent_png
 endif
 
 EXTRA_DIST += \

--- a/tests/gdimagecopyresized/github_bug_00638_transparent_png.c
+++ b/tests/gdimagecopyresized/github_bug_00638_transparent_png.c
@@ -1,0 +1,43 @@
+#include "gd.h"
+#include "gdtest.h"
+
+gdImagePtr createTransparentStripedImage(int size)
+{
+	gdImagePtr im;
+	int white, black;
+
+	im = gdImageCreate(size, size);
+	white = gdImageColorAllocate(im, 255, 255, 255);
+	black = gdImageColorAllocate(im, 0, 0, 0);
+	gdImageFilledRectangle(im, 0, 0, size, size / 2, white);
+	gdImageFilledRectangle(im, 0, size / 2, size, size, black);
+	gdImageColorTransparent(im, white);
+
+	return im;
+}
+
+int main()
+{
+	int error = 0;
+	gdImagePtr src;
+	gdImagePtr dst;
+	gdImagePtr exp;
+
+	src = createTransparentStripedImage(64);
+	dst = gdImageCreate(32, 32);
+
+	gdImageCopyResized(dst, src, 0, 0, 0, 0, 32, 32, 64, 64);
+
+	exp = createTransparentStripedImage(32);
+
+	if (!gdAssertImageEquals(exp, dst)) {
+		gdTestErrorMsg("image differs from expected result");
+		error = 1;
+	}
+
+	gdImageDestroy(src);
+	gdImageDestroy(dst);
+	gdImageDestroy(exp);
+
+	return error;
+}


### PR DESCRIPTION
Fixes #638