### PR TITLE
.travis.yml: close config warning and info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
    # COVERITY_SCAN_TOKEN
    - secure: "h7NGklk0xX2iuY5PgxijE7FFEgd95hxbhSwofs+hzYIiW6FR2kk8gSwEqRH5dYGnvazGT3a7fjxuYAr0y5BQCfV7yyQISl19rYZPJbP9bTxGxijTGlItyQqVTXCaucuXzgJbAOgC1W3ja4lYODflCyFzHhPggJLkXEAw1FF3+5M="
 
-sudo: false
+dist: xenial
 
 # Order here matters; see compiler comment above.
 os:


### PR DESCRIPTION
* sudo is deprecated and has no effect any more
* add dist to specify xenial(Ubuntu 16.04) explicit