### PR TITLE
Fix #615 using libraqm

### DIFF
--- a/src/gdft.c
+++ b/src/gdft.c
@@ -449,6 +449,10 @@ textLayout(uint32_t *text, int len,
 	size_t count;
 	glyphInfo *info;
 
+	if (!len) {
+		return 0;
+	}
+
 #ifdef HAVE_LIBRAQM
 	size_t i;
 	raqm_glyph_t *glyphs;

--- a/src/gdft.c
+++ b/src/gdft.c
@@ -1570,7 +1570,9 @@ BGD_DECLARE(char *) gdImageStringFTEx (gdImage * im, int *brect, int fg, const c
 	}
 
 	gdFree(text);
-	gdFree(info);
+	if (info) {
+		gdFree(info);
+	}
 
 	/* Save the (unkerned) advance from the last character in the xshow vector */
 	if (strex && (strex->flags & gdFTEX_XSHOW) && strex->xshow) {


### PR DESCRIPTION
@cmb69 please review

raqm_get_glyphs fails but this seems expected when len is 0

My first idea was 
```
 	if (!glyphs) {
 		raqm_destroy (rq);
-		return -1;
+		return len ? -1 : 0;
 	}
```

But testing earlier make things faster in all cases.
