### PR TITLE
Remove unistd.h from getopt.c

### DIFF
--- a/src/getopt.c
+++ b/src/getopt.c
@@ -33,7 +33,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
 
 int	opterr = 1,		/* if error message should be printed */
 	optind = 1,		/* index into parent argv vector */

--- a/src/webpng.c
+++ b/src/webpng.c
@@ -10,6 +10,10 @@
 #include <string.h>
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>
+#else
+extern char* optarg;
+extern int optind, opterr, optopt;
+extern int getopt(int argc, char* const argv[], const char* optstring);
 #endif
 
 #ifdef __clang__


### PR DESCRIPTION
1. Correct Windows cmake build: unistd.h doesn't exist on Windows.
2. Handle getopt missing declaration while building with ENABLE_PNG