### PR TITLE
changes for oss fuzz with libtiff and libjpegturbo

### DIFF
--- a/libgd-ossfuzz/Dockerfile
+++ b/libgd-ossfuzz/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && \
+    apt-get install -y make autoconf automake libtool pkg-config libz-dev libtiff-dev libjpeg-turbo8-dev
+RUN git clone --depth 1 https://github.com/libgd/libgd
+ADD https://lcamtuf.coredump.cx/afl/demo/afl_testcases.tgz $SRC/afl_testcases.tgz
+WORKDIR libgd
+COPY build.sh *.cc $SRC/

--- a/libgd-ossfuzz/build.sh
+++ b/libgd-ossfuzz/build.sh
@@ -1,0 +1,49 @@
+#!/bin/bash -eu
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+################################################################################
+
+./bootstrap.sh
+
+# Limit the size of buffer allocations to avoid bogus OOM issues
+# https://github.com/libgd/libgd/issues/422
+sed -i'' -e 's/INT_MAX/100000/' "$SRC/libgd/src/gd_security.c"
+
+./configure --prefix="$WORK" --disable-shared
+make -j$(nproc) install
+
+for target in Bmp Gd Gd2 Gif Jpeg Png Tga Tiff WBMP Webp; do
+    lowercase=$(echo $target | tr "[:upper:]" "[:lower:]")
+    $CXX $CXXFLAGS -std=c++11 -I"$WORK/include" -L"$WORK/lib" \
+      -DFUZZ_GD_FORMAT=$target \
+      $SRC/parser_target.cc -o $OUT/${lowercase}_target \
+      $LIB_FUZZING_ENGINE -ljpeg -ltiff -lgd -Wl,-Bstatic -lz -Wl,-Bdynamic
+done
+
+for fuzzers in $(find $SRC -name '*_fuzzer.cc'); do
+      fuzz_basename=$(basename -s .cc $fuzzers)
+      $CXX $CXXFLAGS -std=c++11 -I"$WORK/include" -L"$WORK/lib" \
+      $fuzzers -o $OUT/$fuzz_basename \
+      $LIB_FUZZING_ENGINE -lgd -Wl,-Bstatic -lz -Wl,-Bdynamic
+done
+
+mkdir afl_testcases
+(cd afl_testcases; tar xvf "$SRC/afl_testcases.tgz")
+for format in bmp gif png webp tif jpg; do
+    mkdir $format
+    find afl_testcases -type f -name '*.'$format -exec mv -n {} $format/ \;
+    zip -rj $format.zip $format/
+    cp $format.zip "$OUT/${format}_target_seed_corpus.zip"
+done

--- a/libgd-ossfuzz/gd_image_string_fuzzer.cc
+++ b/libgd-ossfuzz/gd_image_string_fuzzer.cc
@@ -1,0 +1,53 @@
+// Copyright 2020 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+/////////////////////////////////////////////////////////////////////////////
+
+#include <fuzzer/FuzzedDataProvider.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+
+#include "gd.h"
+#include "gdfontg.h"
+#include "gdfontl.h"
+#include "gdfontmb.h"
+#include "gdfonts.h"
+#include "gdfontt.h"
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size) {
+    FuzzedDataProvider stream(data, size);
+    const uint8_t slate_width = stream.ConsumeIntegral<uint8_t>();
+    const uint8_t slate_height = stream.ConsumeIntegral<uint8_t>();
+    gdImagePtr slate_image = gdImageCreateTrueColor(slate_width, slate_height);
+    if (slate_image == nullptr) {
+      return 0;
+    }
+
+    const int x_position = stream.ConsumeIntegral<int>();
+    const int y_position = stream.ConsumeIntegral<int>();
+    const int text_color = stream.ConsumeIntegral<int>();
+    const gdFontPtr font_ptr = stream.PickValueInArray(
+        {gdFontGetGiant(), gdFontGetLarge(), gdFontGetMediumBold(),
+        gdFontGetSmall(), gdFontGetTiny()});
+    const std::string text = stream.ConsumeRemainingBytesAsString();
+
+    gdImageString(slate_image, font_ptr, x_position, y_position,
+                  reinterpret_cast<uint8_t*>(const_cast<char*>(text.c_str())),
+                  text_color);
+    gdImageDestroy(slate_image);
+    return 0;
+}

--- a/libgd-ossfuzz/parser_target.cc
+++ b/libgd-ossfuzz/parser_target.cc
@@ -1,0 +1,27 @@
+// Copyright 2018 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+/////////////////////////////////////////////////////////////////////////////
+
+#include <stdint.h>
+#include "gd.h"
+
+#define PASTE(x) gdImageCreateFrom ## x ## Ptr
+#define CREATE_IMAGE(FORMAT) PASTE(FORMAT)
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
+    gdImagePtr im = CREATE_IMAGE(FUZZ_GD_FORMAT)(Size, (void*) Data);
+    if (im) gdImageDestroy(im);
+    return 0;
+}

--- a/libgd-ossfuzz/project.yaml
+++ b/libgd-ossfuzz/project.yaml
@@ -1,0 +1,14 @@
+homepage: "https://libgd.org"
+language: c++
+primary_contact: "security@libgd.org"
+auto_ccs:
+  - vapier@gmail.com
+  - tim@tim-smith.us
+  - cmbecker69@gmx.de
+sanitizers:
+  - address
+  - memory
+  - undefined
+architectures:
+  - x86_64
+  - i386


### PR DESCRIPTION
`by` defailt libtiff and libjpegturbo was disabled in libbgd oss fuzz. enabled it.