### PR TITLE
HEIF codecs check in test suite

### DIFF
--- a/tests/heif/heif_im2im.c
+++ b/tests/heif/heif_im2im.c
@@ -7,6 +7,8 @@
 #include "gd.h"
 #include "gdtest.h"
 
+#include <libheif/heif.h>
+
 int main()
 {
 	gdImagePtr src, dst;
@@ -14,6 +16,9 @@ int main()
 	void *p;
 	int size = 0;
 	CuTestImageResult result = {0, 0};
+
+	if (!gdTestAssertMsg(heif_have_decoder_for_format(heif_compression_HEVC) && heif_have_encoder_for_format(heif_compression_HEVC), "HEVC codec support missing from libheif\n"))
+		return 0;
 
 	src = gdImageCreateTrueColor(100, 100);
 	gdTestAssertMsg(src != NULL, "could not create src\n");

--- a/tests/heif/heif_im2im.c
+++ b/tests/heif/heif_im2im.c
@@ -18,7 +18,7 @@ int main()
 	CuTestImageResult result = {0, 0};
 
 	if (!gdTestAssertMsg(heif_have_decoder_for_format(heif_compression_HEVC) && heif_have_encoder_for_format(heif_compression_HEVC), "HEVC codec support missing from libheif\n"))
-		return 0;
+		return 77;
 
 	src = gdImageCreateTrueColor(100, 100);
 	gdTestAssertMsg(src != NULL, "could not create src\n");

--- a/tests/heif/heif_read.c
+++ b/tests/heif/heif_read.c
@@ -15,7 +15,7 @@ int main()
 	FILE *fp;
 
 	if (!gdTestAssertMsg(heif_have_decoder_for_format(heif_compression_HEVC), "HEVC codec support missing from libheif\n"))
-		return 0;
+		return 77;
 
 	fp = gdTestFileOpen2("heif", "label.heic");
 	gdTestAssert(fp != NULL);

--- a/tests/heif/heif_read.c
+++ b/tests/heif/heif_read.c
@@ -7,10 +7,15 @@
 #include "gd.h"
 #include "gdtest.h"
 
+#include <libheif/heif.h>
+
 int main()
 {
 	gdImagePtr im;
 	FILE *fp;
+
+	if (!gdTestAssertMsg(heif_have_decoder_for_format(heif_compression_HEVC), "HEVC codec support missing from libheif\n"))
+		return 0;
 
 	fp = gdTestFileOpen2("heif", "label.heic");
 	gdTestAssert(fp != NULL);


### PR DESCRIPTION
Use the `heif_have_decoder_for_format` and `heif_have_encoder_for_format` functions to find if HEVC decoding/encoding is supported by `libheif`.

Fixes #675.
