### PR TITLE
Fix #679: ssize_t used in gdft.c won't compile under MS compiler

### DIFF
--- a/windows/Makefile.vc
+++ b/windows/Makefile.vc
@@ -146,6 +146,7 @@ CFLAGS= $(CFLAGS) \
        /DHAVE_LIBZ=1\
        /DHAVE_LIBXPM=1\
        /DHAVE_LIBTIFF=1\
+       /DHAVE_CONFIG_H\
        $(INCLUDES)
 
 TEST_CFLAGS=$(CFLAGS)
@@ -225,6 +226,8 @@ make_dirs:
 	@echo #ifndef HAVE_LIBTIFF>> $(GD_CONFIG_H)
 	@echo #define HAVE_LIBTIFF>> $(GD_CONFIG_H)
 	@echo #endif>> $(GD_CONFIG_H)
+	@echo #define ssize_t SSIZE_T>> $(GD_CONFIG_H)
+	@echo #define SSIZE_MAX MAXSSIZE_T>> $(GD_CONFIG_H)
 
 run_tests: pretest
 	@cd $(TDR)


### PR DESCRIPTION
MSVC does not define `ssize_t` (nor `SSIZE_MAX`), so we add fallback
definitions to the generated config.h.

We also need to define `HAVE_CONFIG_H` which makes most of the other
defines there superfluous, but we leave them in since they don't hurt.