### PR TITLE
raise libheif minimal version to 1.9.0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -286,7 +286,7 @@ GD_LIB_PKG_CHECK([LIBWEBP], [WEBP], [webp], [libwebp], [
 ])
 
 dnl Check for heif support.
-GD_LIB_PKG_CHECK([LIBHEIF], [HEIF], [heif], [libheif >= 1.7.0], [
+GD_LIB_PKG_CHECK([LIBHEIF], [HEIF], [heif], [libheif >= 1.9.0], [
   AC_CHECK_LIB([heif], [heif_get_version], [dnl
     AS_VAR_APPEND([LIBHEIF_LIBS], [" -lheif"])
   ])


### PR DESCRIPTION
See #678

Segfault with 1.8.0
Tested, OK with 1.9.1, 1.10.0 and 1.11.0


ping @YakoYakoYokuYoku 