### PR TITLE
Permit compilation with libheif version 1.7.0

### DIFF
--- a/src/gd_heif.c
+++ b/src/gd_heif.c
@@ -321,6 +321,7 @@ static int _gdImageHeifCtx(gdImagePtr im, gdIOCtx *outfile, int quality, gdHeifC
 		return GD_FALSE;
 	}
 
+#if LIBHEIF_HAVE_VERSION(1, 9, 0)
 	err = heif_encoder_set_parameter_string(heif_enc, "chroma", chroma);
 	if (err.code != heif_error_Ok) {
 		gd_error("gd-heif invalid chroma subsampling parameter\n");
@@ -328,6 +329,9 @@ static int _gdImageHeifCtx(gdImagePtr im, gdIOCtx *outfile, int quality, gdHeifC
 		heif_context_free(heif_ctx);
 		return GD_FALSE;
 	}
+#else
+	(void)chroma;
+#endif
 
 	err = heif_image_create(gdImageSX(im), gdImageSY(im), heif_colorspace_RGB, heif_chroma_interleaved_RGBA, &heif_im);
 	if (err.code != heif_error_Ok) {

--- a/src/gd_heif.c
+++ b/src/gd_heif.c
@@ -329,8 +329,6 @@ static int _gdImageHeifCtx(gdImagePtr im, gdIOCtx *outfile, int quality, gdHeifC
 			heif_context_free(heif_ctx);
 			return GD_FALSE;
 		}
-	} else {
-		(void)chroma;
 	}
 
 	err = heif_image_create(gdImageSX(im), gdImageSY(im), heif_colorspace_RGB, heif_chroma_interleaved_RGBA, &heif_im);

--- a/src/gd_heif.c
+++ b/src/gd_heif.c
@@ -321,17 +321,17 @@ static int _gdImageHeifCtx(gdImagePtr im, gdIOCtx *outfile, int quality, gdHeifC
 		return GD_FALSE;
 	}
 
-#if LIBHEIF_HAVE_VERSION(1, 9, 0)
-	err = heif_encoder_set_parameter_string(heif_enc, "chroma", chroma);
-	if (err.code != heif_error_Ok) {
-		gd_error("gd-heif invalid chroma subsampling parameter\n");
-		heif_encoder_release(heif_enc);
-		heif_context_free(heif_ctx);
-		return GD_FALSE;
+	if (heif_get_version_number_major() >= 1 && heif_get_version_number_minor() >= 9) {
+		err = heif_encoder_set_parameter_string(heif_enc, "chroma", chroma);
+		if (err.code != heif_error_Ok) {
+			gd_error("gd-heif invalid chroma subsampling parameter\n");
+			heif_encoder_release(heif_enc);
+			heif_context_free(heif_ctx);
+			return GD_FALSE;
+		}
+	} else {
+		(void)chroma;
 	}
-#else
-	(void)chroma;
-#endif
 
 	err = heif_image_create(gdImageSX(im), gdImageSY(im), heif_colorspace_RGB, heif_chroma_interleaved_RGBA, &heif_im);
 	if (err.code != heif_error_Ok) {

--- a/tests/heif/heif_im2im.c
+++ b/tests/heif/heif_im2im.c
@@ -16,8 +16,8 @@ int main()
 	void *p;
 	int size = 0;
 	CuTestImageResult result = {0, 0};
-	
-	if (gdTestAssertMsg(heif_get_version_number_major() == 1 && heif_get_version_number_minor() >= 9, "changing chroma subsampling is not supported in this libheif version\n"))
+
+	if (!gdTestAssertMsg(heif_get_version_number_major() == 1 && heif_get_version_number_minor() >= 9, "changing chroma subsampling is not supported in this libheif version\n"))
 		return 77;
 
 	if (!gdTestAssertMsg(heif_have_decoder_for_format(heif_compression_HEVC) && heif_have_encoder_for_format(heif_compression_HEVC), "HEVC codec support missing from libheif\n"))

--- a/tests/heif/heif_im2im.c
+++ b/tests/heif/heif_im2im.c
@@ -16,6 +16,9 @@ int main()
 	void *p;
 	int size = 0;
 	CuTestImageResult result = {0, 0};
+	
+	if (gdTestAssertMsg(heif_get_version_number_major() == 1 && heif_get_version_number_minor() >= 9, "changing chroma subsampling is not supported in this libheif version\n"))
+		return 77;
 
 	if (!gdTestAssertMsg(heif_have_decoder_for_format(heif_compression_HEVC) && heif_have_encoder_for_format(heif_compression_HEVC), "HEVC codec support missing from libheif\n"))
 		return 77;


### PR DESCRIPTION
`libheif` versions that came before `1.9.0` don't support changing the output image chroma. I did not notice that and it resulted with tests failures across other OSes that don't have a much newer `libheif`.

See #678. Supersedes #685.
