### PR TITLE
Minor AVIF fixes

### DIFF
--- a/src/gd_avif.c
+++ b/src/gd_avif.c
@@ -374,7 +374,7 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromAvifCtx (gdIOCtx *ctx)
 		goto cleanup;
 
 	if (!isAvifSrgbImage(decoder->image))
-		gd_error_ex(LOG_WARNING, "Image's color profile is not sRGB");
+		gd_error_ex(LOG_NOTICE, "Image's color profile is not sRGB");
 
 	// Set up the avifRGBImage, and convert it from YUV to an 8-bit RGB image.
 	// (While AVIF image pixel depth can be 8, 10, or 12 bits, GD truecolor images are 8-bit.)

--- a/src/gd_avif.c
+++ b/src/gd_avif.c
@@ -191,7 +191,7 @@ static avifResult readFromCtx(avifIO *io, uint32_t readFlags, uint64_t offset, s
 	if (!ctx->seek(ctx, (int) offset))
 		return AVIF_RESULT_IO_ERROR;
 
-	dataBuf = gdMalloc(size);
+	dataBuf = avifMalloc(size);
 	if (!dataBuf) {
 		gd_error("avif error - couldn't allocate memory");
 		return AVIF_RESULT_UNKNOWN_ERROR;
@@ -201,7 +201,7 @@ static avifResult readFromCtx(avifIO *io, uint32_t readFlags, uint64_t offset, s
 	// If getBuf() returns a negative value, that means there was an error.
 	int charsRead = ctx->getBuf(ctx, dataBuf, (int) size);
 	if (charsRead < 0) {
-		gdFree(dataBuf);
+		avifFree(dataBuf);
 		return AVIF_RESULT_IO_ERROR;
 	}
 


### PR DESCRIPTION
These are inspired by the work I've done to propagate libgd's AVIF support into PHP's bundled gd fork.

One of these changes fixes a small memory leak.

In the other - in the original PR, I hadn't realized that `gd_error()` outputs a `LOG_WARNING`. I use `gd_error()` throughout `gd_avif.c`, except for the case where we notice that an image's color profile isn't sRGB. This message is significant, but not as much as the errors that occur when we can't process the user's request at all. So I'd explicitly used `LOG_WARNING`.

That makes no sense, though, if we'd be outputting a `LOG_WARNING` level anyway! So I've just downgraded this one to `LOG_NOTICE`.

Others will have more experience than I do with libgd error levels; I'd cheerfully defer to them here.