### PR TITLE
fix read out-of-bounds in reading tga header file

### DIFF
--- a/src/gd_tga.c
+++ b/src/gd_tga.c
@@ -191,7 +191,11 @@ int read_header_tga(gdIOCtx *ctx, oTga *tga)
 			return -1;
 		}
 
-		gdGetBuf(tga->ident, tga->identsize, ctx);
+		
+		if (gdGetBuf(tga->ident, tga->identsize, ctx) != tga->identsize) {
+			gd_error("fail to read header ident");
+			return -1;
+		}
 	}
 
 	return 1;


### PR DESCRIPTION
Update src/gd_tga.c file for possible read out of bound in `gdGetBuf` call site.
Mentioned in this issue #697.