### PR TITLE
Fix #415, Assuming TopOfs and LeftOfs zero, we can safely skip any (x…

### DIFF
--- a/src/gd_gif_out.c
+++ b/src/gd_gif_out.c
@@ -768,6 +768,8 @@ break_bot:
 			/* left side */
 			for (x = 0; x < min_x; ++x) {
 				for (y = min_y; y <= max_y; ++y) {
+					if (!gdImageBoundsSafe(prev_tim, x,y))
+						continue;
 					if (!comparewithmap
 					        (prev_tim, tim,
 					         prev_tim->pixels[y][x],
@@ -783,6 +785,8 @@ break_left:
 			/* right side */
 			for (x = tim->sx - 1; x > max_x; --x) {
 				for (y = min_y; y <= max_y; ++y) {
+					if (!gdImageBoundsSafe(prev_tim, x,y))
+						continue;
 					if (!comparewithmap
 					        (prev_tim, tim,
 					         prev_tim->pixels[y][x],

--- a/src/gd_gif_out.c
+++ b/src/gd_gif_out.c
@@ -745,6 +745,8 @@ break_top:
 			/* Then the bottom row */
 			for (y = tim->sy - 1; y > min_y; --y) {
 				for (x = 0; x < tim->sx; ++x) {
+					if (!gdImageBoundsSafe(prev_tim, x,y))
+						continue;
 					if (!comparewithmap
 					        (prev_tim, tim,
 					         prev_tim->pixels[y][x],

--- a/tests/gif/CMakeLists.txt
+++ b/tests/gif/CMakeLists.txt
@@ -11,6 +11,7 @@ LIST(APPEND TESTS_FILES
 	bug00006
 	bug00060
 	gif_im2im
+	bug00415
 )
 
 IF(PNG_FOUND)

--- a/tests/gif/bug00415.c
+++ b/tests/gif/bug00415.c
@@ -1,0 +1,27 @@
+#include <gd.h>
+#include "gdtest.h"
+
+int main()
+{
+    gdImagePtr im1, im2;
+
+    im1 = gdImageCreate(100, 100);
+    gdImageColorAllocate(im1, 0, 0, 0);
+    im2 = gdImageCreate(10, 10);
+    gdImageColorAllocate(im2, 255, 255, 255);
+
+    FILE *fp = gdTestTempFp();
+    if (!fp) return 4;
+    gdImageGifAnimBegin(im1, fp, 0, 0);
+    gdImageGifAnimAdd(im1, fp, 1, 0, 0, 100, 1, NULL);
+    gdImageGifAnimAdd(im2, fp, 1, 0, 0, 100, 1, im1);
+    // replacing `im2` with `NULL` in the following line succeeds
+    gdImageGifAnimAdd(im1, fp, 1, 0, 0, 100, 1, im2);
+    gdImageGifAnimEnd(fp);
+    fclose(fp);
+
+    gdImageDestroy(im1);
+    gdImageDestroy(im2);
+
+    return 0;
+}


### PR DESCRIPTION
Assuming TopOfs and LeftOfs zero, we can safely skip any (x…y) out of the previous image bounds
Result with the fix:
![415](https://user-images.githubusercontent.com/282408/130745137-6f8fe918-85ca-4390-8394-878fcf304969.gif)
