### PR TITLE
Close #334: gdColorMatch(): doubtful algorithm

### DIFF
--- a/src/gd_color.c
+++ b/src/gd_color.c
@@ -7,6 +7,10 @@
 #include <math.h>
 
 /**
+ * Checks whether two given colors match according to a given threshold in
+ * range [0..100]. dist is the euclidian distance of the color channels in
+ * range [0..2].
+ *
  * The threshold method works relatively well but it can be improved.
  * Maybe L*a*b* and Delta-E will give better results (and a better
  * granularity).

--- a/src/gd_color.c
+++ b/src/gd_color.c
@@ -4,6 +4,7 @@
 
 #include "gd.h"
 #include "gd_color.h"
+#include <math.h>
 
 /**
  * The threshold method works relatively well but it can be improved.
@@ -12,13 +13,13 @@
  */
 int gdColorMatch(gdImagePtr im, int col1, int col2, float threshold)
 {
-	const int dr = gdImageRed(im, col1) - gdImageRed(im, col2);
-	const int dg = gdImageGreen(im, col1) - gdImageGreen(im, col2);
-	const int db = gdImageBlue(im, col1) - gdImageBlue(im, col2);
-	const int da = gdImageAlpha(im, col1) - gdImageAlpha(im, col2);
-	const int dist = dr * dr + dg * dg + db * db + da * da;
+    const float dr = (gdImageRed(im, col1) - gdImageRed(im, col2)) / (float) gdRedMax;
+    const float dg = (gdImageGreen(im, col1) - gdImageGreen(im, col2)) / (float) gdGreenMax;
+    const float db = (gdImageBlue(im, col1) - gdImageBlue(im, col2)) / (float) gdBlueMax;
+    const float da = (gdImageAlpha(im, col1) - gdImageAlpha(im, col2)) / (float) gdAlphaMax;
+    const float dist = sqrtf(dr * dr + dg * dg + db * db + da * da);
 
-	return 100.0 * dist < threshold * 195075.0;
+    return 100 * dist < 2 * threshold;
 }
 
 /*

--- a/tests/gdimagecolorreplace/gdimagecolorreplace.c
+++ b/tests/gdimagecolorreplace/gdimagecolorreplace.c
@@ -119,7 +119,7 @@ static void run_tests(gdImagePtr im, int *error)
 	gdImageSetPixel(im, 3, 2, seashell)
 
 	INITIALIZE_IMAGE();
-	n = gdImageColorReplaceThreshold(im, white, yellow, 2.0);
+	n = gdImageColorReplaceThreshold(im, white, yellow, 10.0);
 	CHECK_VALUE(n, 9);
 	CHECK_PIXEL(0, 0, black);
 	CHECK_PIXEL(1, 1, yellow);


### PR DESCRIPTION
We change the algorithm of `gdColorMatch()` to calculate the Euclidean
distance of the color component values, what may require to change some
thresholds in existing code to match the new algorithm, as can be seen
by the need to adapt gdimagecolorreplace.c.