### PR TITLE
Fix #764 prevent crash in test code when AVIF encode/decode fails, fi…

### DIFF
--- a/tests/avif/avif_im2im.c
+++ b/tests/avif/avif_im2im.c
@@ -13,7 +13,7 @@
 
 int main()
 {
-	gdImagePtr srcGdIm, destGdIm;
+	gdImagePtr srcGdIm = NULL, destGdIm = NULL;
 	void *avifImageDataPtr;
 	FILE *fp;
 	int r, g, b;
@@ -38,7 +38,7 @@ int main()
 
 	// Encode the gd image to an AVIF image in memory.
 	avifImageDataPtr = gdImageAvifPtrEx(srcGdIm, &size, 100, 10);
-	gdTestAssertMsg(avifImageDataPtr != NULL, "gdImageAvifPtr() returned null\n");
+	if (!gdTestAssertMsg(avifImageDataPtr != NULL, "gdImageAvifPtr() returned null\n")) goto exit;
 	gdTestAssertMsg(size > 0, "gdImageAvifPtr() returned a non-positive size\n");
 
 	// Encode the AVIF image back into a gd image.
@@ -54,6 +54,7 @@ int main()
 	 gdTestImageDiff(srcGdIm, destGdIm, NULL, &result);
 	 gdTestAssertMsg(result.pixels_changed == 0, "pixels changed: %d\n", result.pixels_changed);
 
+exit:
 	if (srcGdIm)
 		gdImageDestroy(srcGdIm);
 

--- a/tests/avif/compare_avif_to_png.c
+++ b/tests/avif/compare_avif_to_png.c
@@ -20,7 +20,7 @@
 int main() {
 	FILE *fp;
 	gdImagePtr imFromPng = NULL, imFromAvif = NULL;
-	void *avifImDataPtr = NULL, *pngImDataPtr = NULL;
+	void *avifImDataPtr = NULL;
 	int size;
 	char pngFilename[100], avifFilename[100], *pngFilePath;
 	char errMsg[4096];
@@ -56,37 +56,12 @@ int main() {
 		gdTestAssertMsg(gdAssertImageEquals(imFromPng, imFromAvif), errMsg);
 
 		// Then, decode each AVIF into a GD format, and compare that with the orginal PNG.
-avif2png:
-
 		// Skip this reverse test for now, until we can find images that encode to PNGs losslessly.
-if (0) {
-		sprintf(avifFilename, "%s.avif", filenames[i]);
-		fp = gdTestFileOpen2("avif", avifFilename);
-		imFromAvif = gdImageCreateFromAvif(fp);
-		fclose(fp);
-
-		strcat(strcpy(errMsg, filenames[i]), ".avif: gdImageCreateFromAvif failed\n");
-		if (!gdTestAssertMsg(imFromAvif != NULL, errMsg))
-			continue;
-
-		strcat(strcpy(errMsg, filenames[i]), ".avif: Encoded PNG image did not match original AVIF\n");
-		pngFilePath = gdTestFilePath2("avif", pngFilename);
-		gdTestAssertMsg(gdAssertImageEqualsToFile(pngFilePath, imFromAvif), errMsg);
-		free(pngFilePath);
-}
+avif2png:
+		if (imFromPng) gdImageDestroy(imFromPng);
+		if (imFromAvif) gdImageDestroy(imFromAvif);
+		if (avifImDataPtr) gdFree(avifImDataPtr);
 	}
-
-	if (imFromPng)
-		gdImageDestroy(imFromPng);
-
-	if (imFromAvif)
-		gdImageDestroy(imFromAvif);
-
-	if (avifImDataPtr)
-		gdFree(avifImDataPtr);
-
-	if (pngImDataPtr)
-		gdFree(pngImDataPtr);
 
 	return gdNumFailures();
 }


### PR DESCRIPTION
Fix #764 prevent crash in test code when AVIF encode/decode fails, fix memory leaks