### PR TITLE
fix help string (as off by default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.3.3] - 2021-09-12
 
+### Changed
+
+- support for the legacy/testing gd image formats is disabled by default
+
 ### Fixed
 
 - [#759](https://github.com/libgd/libgd/issues/759) update cmake to generate config.h in the build dir

--- a/configure.ac
+++ b/configure.ac
@@ -104,7 +104,7 @@ AX_OPENMP()
 dnl We should default this to off in future releases.
 AC_MSG_CHECKING([whether to support gd image formats])
 AC_ARG_ENABLE([gd-formats],
-  [AS_HELP_STRING([--disable-gd-formats], [Disable support for the legacy/testing gd image formats])],
+  [AS_HELP_STRING([--enable-gd-formats], [Enable support for the legacy/testing gd image formats])],
   [gd_enable_gd_formats=$enableval],
   [gd_enable_gd_formats=no])
 AC_MSG_RESULT([$gd_enable_gd_formats])


### PR DESCRIPTION
As off by default since c6af75565ad00732d71064edddfb7a8ea3e0b26b