### PR TITLE
docs: Fix a few typos

### DIFF
--- a/examples/copyrotated.c
+++ b/examples/copyrotated.c
@@ -51,8 +51,8 @@ int main(int argc, char **arg)
 	}
 
 	/*
-		cos adj hyp (cos = adjacent / hypothenus)
-		sin op hyp (sin adjacent / hypothenus)
+		cos adj hyp (cos = adjacent / hypotenuse)
+		sin op hyp (sin adjacent / hypotenuse)
 		+ 10 pixels margin
 	 */
 

--- a/src/gd.c
+++ b/src/gd.c
@@ -3629,7 +3629,7 @@ BGD_DECLARE(void) gdImageOpenPolygon (gdImagePtr im, gdPointPtr p, int n, int c)
 /* THANKS to Kirsten Schulz for the polygon fixes! */
 
 /* The intersection finding technique of this code could be improved  */
-/* by remembering the previous intertersection, and by using the slope. */
+/* by remembering the previous intersection, and by using the slope. */
 /* That could help to adjust intersections  to produce a nice */
 /* interior_extrema. */
 

--- a/src/gd.h
+++ b/src/gd.h
@@ -406,7 +406,7 @@ typedef double (* interpolation_method )(double, double);
      <Accessor Macros>
 
    (Previous versions of this library encouraged directly manipulating
-   the contents ofthe struct but we are attempting to move away from
+   the contents of the struct but we are attempting to move away from
    this practice so the fields are no longer documented here.  If you
    need to poke at the internals of this struct, feel free to look at
    *gd.h*.)

--- a/src/gd_avif.c
+++ b/src/gd_avif.c
@@ -464,7 +464,7 @@ cleanup:
 		speed - At slower speeds, encoding may be quite slow. Use judiciously.
 
 		Qualities or speeds that are lower than the minimum value get clamped to the minimum value,
-		and qualities or speeds that are lower than the maximum value get clamped to the maxmum value.
+		and qualities or speeds that are lower than the maximum value get clamped to the maximum value.
 		Note that AVIF_SPEED_DEFAULT is -1. If we ever set SPEED_DEFAULT = AVIF_SPEED_DEFAULT,
 		we'd want to add a conditional to ensure that value doesn't get clamped.
 

--- a/src/gd_nnquant.c
+++ b/src/gd_nnquant.c
@@ -536,7 +536,7 @@ BGD_DECLARE(gdImagePtr) gdImageNeuQuant(gdImagePtr im, const int max_color, int 
 	 * This implementation works with aligned contiguous buffer only
 	 * Upcoming new buffers are contiguous and will be much faster.
 	 * let don't bloat this code to support our good "old" 31bit format.
-	 * It alos lets us convert palette image, if one likes to reduce
+	 * It also lets us convert palette image, if one likes to reduce
 	 * a palette
 	 */
 	if (overflow2(gdImageSX(im), gdImageSY(im))

--- a/src/gd_tga.c
+++ b/src/gd_tga.c
@@ -237,7 +237,7 @@ int read_image_tga( gdIOCtx *ctx, oTga *tga )
 	if (tga->imagetype != TGA_TYPE_RGB && tga->imagetype != TGA_TYPE_RGB_RLE)
 		return -1;
 
-	/*!	\brief Allocate memmory for image block
+	/*!	\brief Allocate memory for image block
 	 *  Allocate a chunk of memory for the image block to be passed into.
 	 */
 	tga->bitmap = (int *) gdMalloc(image_block_size * sizeof(int));

--- a/src/gd_topal.c
+++ b/src/gd_topal.c
@@ -1589,7 +1589,7 @@ static int gdImageTrueColorToPaletteBody (gdImagePtr oim, int dither, int colors
 
 
 	if (oim->paletteQuantizationMethod == GD_QUANT_NEUQUANT) {
-		if (cimP) { /* NeuQuant alwasy creates a copy, so the new blank image can't be used */
+		if (cimP) { /* NeuQuant always creates a copy, so the new blank image can't be used */
 			gdImageDestroy(nim);
 		}
 		nim = gdImageNeuQuant(oim, colorsWanted, oim->paletteQuantizationSpeed ? oim->paletteQuantizationSpeed : 2);

--- a/src/wbmp.c
+++ b/src/wbmp.c
@@ -33,7 +33,7 @@
  * Get a multibyte integer from a generic getin function
  * 'getin' can be getc, with in = NULL
  * you can find getin as a function just above the main function
- * This way you gain a lot of flexibilty about how this package
+ * This way you gain a lot of flexibility about how this package
  * reads a wbmp file.
  */
 int getmbi(int (*getin) (void *in), void *in)

--- a/tests/avif/compare_avif_to_png.c
+++ b/tests/avif/compare_avif_to_png.c
@@ -2,7 +2,7 @@
  * File: compare_avif_to_png
  *
  * Thorough check for AVIF encoding and decoding.
- * This test reqiures a set of PNG images that have been losslessly encoded to AVIFs.
+ * This test requires a set of PNG images that have been losslessly encoded to AVIFs.
  * For each such image, we encode the PNG into an AVIF, with the GD format as an intermediary,
  * then compare the resulting AVIF with the original PNG.
  *


### PR DESCRIPTION
There are small typos in:
- examples/copyrotated.c
- src/gd.c
- src/gd.h
- src/gd_avif.c
- src/gd_nnquant.c
- src/gd_tga.c
- src/gd_topal.c
- src/wbmp.c
- tests/avif/compare_avif_to_png.c

Fixes:
- Should read `requires` rather than `reqiures`.
- Should read `of the` rather than `ofthe`.
- Should read `memory` rather than `memmory`.
- Should read `maximum` rather than `maxmum`.
- Should read `intersection` rather than `intertersection`.
- Should read `hypotenuse` rather than `hypothenus`.
- Should read `flexibility` rather than `flexibilty`.
- Should read `always` rather than `alwasy`.
- Should read `also` rather than `alos`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md