### PR TITLE
Improve image crop performance

### DIFF
--- a/src/gd_color.c
+++ b/src/gd_color.c
@@ -18,7 +18,7 @@ int gdColorMatch(gdImagePtr im, int col1, int col2, float threshold)
 	const int da = gdImageAlpha(im, col1) - gdImageAlpha(im, col2);
 	const int dist = dr * dr + dg * dg + db * db + da * da;
 
-	return (100.0 * dist / 195075) < threshold;
+	return 100.0 * dist < threshold * 195075.0;
 }
 
 /*

--- a/src/gd_crop.c
+++ b/src/gd_crop.c
@@ -147,7 +147,7 @@ BGD_DECLARE(gdImagePtr) gdImageCropAuto(gdImagePtr im, const unsigned int mode)
 
 	match = 1;
 	for (x = 0; match && x < width; x++) {
-		for (y = 0; match && y < crop.y + crop.height; y++) {
+		for (y = crop.y; match && y < crop.y + crop.height; y++) {
 			match = (color == gdImageGetPixel(im, x,y));
 		}
 	}
@@ -155,7 +155,7 @@ BGD_DECLARE(gdImagePtr) gdImageCropAuto(gdImagePtr im, const unsigned int mode)
 
 	match = 1;
 	for (x = width - 1; match && x >= 0; x--) {
-		for (y = 0; match &&  y < crop.y + crop.height; y++) {
+		for (y = crop.y; match &&  y < crop.y + crop.height; y++) {
 			match = (color == gdImageGetPixel(im, x,y));
 		}
 	}
@@ -236,7 +236,7 @@ BGD_DECLARE(gdImagePtr) gdImageCropThreshold(gdImagePtr im, const unsigned int c
 
 	match = 1;
 	for (x = 0; match && x < width; x++) {
-		for (y = 0; match && y < crop.y + crop.height; y++) {
+		for (y = crop.y; match && y < crop.y + crop.height; y++) {
 			match = (gdColorMatch(im, color, gdImageGetPixel(im, x,y), threshold)) > 0;
 		}
 	}
@@ -244,7 +244,7 @@ BGD_DECLARE(gdImagePtr) gdImageCropThreshold(gdImagePtr im, const unsigned int c
 
 	match = 1;
 	for (x = width - 1; match && x >= 0; x--) {
-		for (y = 0; match &&  y < crop.y + crop.height; y++) {
+		for (y = crop.y; match &&  y < crop.y + crop.height; y++) {
 			match = (gdColorMatch(im, color, gdImageGetPixel(im, x,y), threshold)) > 0;
 		}
 	}

--- a/src/gd_crop.c
+++ b/src/gd_crop.c
@@ -87,8 +87,8 @@ BGD_DECLARE(gdImagePtr) gdImageCropAuto(gdImagePtr im, const unsigned int mode)
 	const int width = gdImageSX(im);
 	const int height = gdImageSY(im);
 
-	int x,y;
-	int color, match;
+	int x, y;
+	int color;
 	gdRect crop;
 
 	crop.x = 0;
@@ -119,47 +119,54 @@ BGD_DECLARE(gdImagePtr) gdImageCropAuto(gdImagePtr im, const unsigned int mode)
 		break;
 	}
 
-	/* TODO: Add gdImageGetRowPtr and works with ptr at the row level
-	 * for the true color and palette images
-	 * new formats will simply work with ptr
-	 */
-	match = 1;
-	for (y = 0; match && y < height; y++) {
-		for (x = 0; match && x < width; x++) {
-			match = (color == gdImageGetPixel(im, x,y));
+	for (x = 0, y = 0; y < height; y++) {
+		for (x = 0; x < width; x++) {
+			if (color != gdImageGetPixel(im, x, y)) {
+				goto break1;
+			}
 		}
 	}
+	break1:
 
 	/* Whole image would be cropped > bye */
-	if (match) {
+	if (y == height && x == width) {
 		return NULL;
 	}
 
-	crop.y = y - 1;
+	crop.y = y;
 
-	match = 1;
-	for (y = height - 1; match && y >= 0; y--) {
-		for (x = 0; match && x < width; x++) {
-			match = (color == gdImageGetPixel(im, x,y));
+	for (y = height - 1; y >= 0; y--) {
+		for (x = 0; x < width; x++) {
+			if (color != gdImageGetPixel(im, x, y)) {
+				goto break2;
+			}
 		}
 	}
-	crop.height = y - crop.y + 2;
+	break2:
 
-	match = 1;
-	for (x = 0; match && x < width; x++) {
-		for (y = crop.y; match && y < crop.y + crop.height; y++) {
-			match = (color == gdImageGetPixel(im, x,y));
+	crop.height = y - crop.y + 1;
+
+	for (x = 0; x < width; x++) {
+		for (y = crop.y; y < crop.y + crop.height; y++) {
+			if (color != gdImageGetPixel(im, x, y)) {
+				goto break3;
+			}
 		}
 	}
-	crop.x = x - 1;
+	break3:
 
-	match = 1;
-	for (x = width - 1; match && x >= 0; x--) {
-		for (y = crop.y; match &&  y < crop.y + crop.height; y++) {
-			match = (color == gdImageGetPixel(im, x,y));
+	crop.x = x;
+
+	for (x = width - 1; x >= 0; x--) {
+		for (y = crop.y; y < crop.y + crop.height; y++) {
+			if (color != gdImageGetPixel(im, x, y)) {
+				goto break4;
+			}
 		}
 	}
-	crop.width = x - crop.x + 2;
+	break4:
+
+	crop.width = x - crop.x + 1;
 
 	return gdImageCrop(im, &crop);
 }
@@ -190,8 +197,7 @@ BGD_DECLARE(gdImagePtr) gdImageCropThreshold(gdImagePtr im, const unsigned int c
 	const int width = gdImageSX(im);
 	const int height = gdImageSY(im);
 
-	int x,y;
-	int match;
+	int x, y;
 	gdRect crop;
 
 	crop.x = 0;
@@ -199,7 +205,7 @@ BGD_DECLARE(gdImagePtr) gdImageCropThreshold(gdImagePtr im, const unsigned int c
 	crop.width = 0;
 	crop.height = 0;
 
-	/* Pierre: crop everything sounds bad */
+	/* To crop everything sounds bad */
 	if (threshold > 100.0) {
 		return NULL;
 	}
@@ -208,47 +214,54 @@ BGD_DECLARE(gdImagePtr) gdImageCropThreshold(gdImagePtr im, const unsigned int c
 		return NULL;
 	}
 
-	/* TODO: Add gdImageGetRowPtr and works with ptr at the row level
-	 * for the true color and palette images
-	 * new formats will simply work with ptr
-	 */
-	match = 1;
-	for (y = 0; match && y < height; y++) {
-		for (x = 0; match && x < width; x++) {
-			match = (gdColorMatch(im, color, gdImageGetPixel(im, x,y), threshold)) > 0;
+	for (x = 0, y = 0; y < height; y++) {
+		for (x = 0; x < width; x++) {
+			if (!gdColorMatch(im, color, gdImageGetPixel(im, x, y), threshold)) {
+				goto break1;
+			}
 		}
 	}
+	break1:
 
 	/* Whole image would be cropped > bye */
-	if (match) {
+	if (y == height && x == width) {
 		return NULL;
 	}
 
-	crop.y = y - 1;
+	crop.y = y;
 
-	match = 1;
-	for (y = height - 1; match && y >= 0; y--) {
-		for (x = 0; match && x < width; x++) {
-			match = (gdColorMatch(im, color, gdImageGetPixel(im, x, y), threshold)) > 0;
+	for (y = height - 1; y >= 0; y--) {
+		for (x = 0; x < width; x++) {
+			if (!gdColorMatch(im, color, gdImageGetPixel(im, x, y), threshold)) {
+				goto break2;
+			}
 		}
 	}
-	crop.height = y - crop.y + 2;
+	break2:
 
-	match = 1;
-	for (x = 0; match && x < width; x++) {
-		for (y = crop.y; match && y < crop.y + crop.height; y++) {
-			match = (gdColorMatch(im, color, gdImageGetPixel(im, x,y), threshold)) > 0;
+	crop.height = y - crop.y + 1;
+
+	for (x = 0; x < width; x++) {
+		for (y = crop.y; y < crop.y + crop.height; y++) {
+			if (!gdColorMatch(im, color, gdImageGetPixel(im, x, y), threshold)) {
+				goto break3;
+			}
 		}
 	}
-	crop.x = x - 1;
+	break3:
 
-	match = 1;
-	for (x = width - 1; match && x >= 0; x--) {
-		for (y = crop.y; match &&  y < crop.y + crop.height; y++) {
-			match = (gdColorMatch(im, color, gdImageGetPixel(im, x,y), threshold)) > 0;
+	crop.x = x;
+
+	for (x = width - 1; x >= 0; x--) {
+		for (y = crop.y; y < crop.y + crop.height; y++) {
+			if (!gdColorMatch(im, color, gdImageGetPixel(im, x, y), threshold)) {
+				goto break4;
+			}
 		}
 	}
-	crop.width = x - crop.x + 2;
+	break4:
+
+	crop.width = x - crop.x + 1;
 
 	return gdImageCrop(im, &crop);
 }


### PR DESCRIPTION
I would like to suggest some small performance tweaks to the image cropping. Most significantly, one can start the loop at y = crop.y instead of 0 when cropping horizontally, since these corners were already handled in the vertical crop. Using goto only makes a small performance difference, but I think it also makes the routine easier to read. The PHP code below I used to test the performance difference on some test image.

```
<?php

$imageblob = file_get_contents('uncropped.png');
$bitmap = imagecreatefromstring($imageblob);
$time = microtime(true);
for ($i = 0; $i < 100; ++$i) {
	$cropped = imagecropauto($bitmap, IMG_CROP_THRESHOLD, 0.5, 0xFFFFFF);
	imagedestroy($cropped);
}
print(microtime(true) - $time);

#$cropped = imagecropauto($bitmap, IMG_CROP_THRESHOLD, 0.5, 0xFFFFFF);
#imagepng($cropped, 'cropped.png');

# Unmodified cropping algorithm: 2.50 s
# Removed duplicate traversal of crop region: 2.33 s
# + Replaced division by multiplication: 2.26 s
# + Replaced match by goto: 2.22 s
# This is an 11% improvement.
```