### PR TITLE
Prevent libpng warning when loading interlaced PNG

### DIFF
--- a/src/gd_png.c
+++ b/src/gd_png.c
@@ -415,6 +415,11 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromPngCtx (gdIOCtx * infile)
 		goto error;
 	}
 
+	/* enable the interlace transform if supported */
+#ifdef PNG_READ_INTERLACING_SUPPORTED
+	(void)png_set_interlace_handling(png_ptr);
+#endif
+
 	png_read_update_info (png_ptr, info_ptr);
 
 	/* allocate space for the PNG image data */


### PR DESCRIPTION
Currently a warning is being generated when reading interlaced PNGs due to libpng being used incorrectly.

Refer to https://github.com/glennrp/libpng/blob/libpng16/pngread.c#L727 for the source of this warning.

This PR enables the interlacing transform prior to calling `png_read_update_info()` to prevent this warning. There is no change in functionality since libpng automatically does this after emitting the warning anyway.