### PR TITLE
WebPDecodeARGB()'s return should be WebPFree()ed.

### DIFF
--- a/src/gd_webp.c
+++ b/src/gd_webp.c
@@ -229,7 +229,7 @@ static int _gdImageWebpCtx (gdImagePtr im, gdIOCtx * outfile, int quality)
 	}
 
 	int res = gdPutBuf(out, out_size, outfile);
-	free(out);
+	WebPFree(out);
 	if (res != out_size) {
 		gd_error("gd-webp write error\n");
 		ret = 1;

--- a/src/gd_webp.c
+++ b/src/gd_webp.c
@@ -157,7 +157,7 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromWebpCtx (gdIOCtx * infile)
 		}
 	}
 	/* do not use gdFree here, in case gdFree/alloc is mapped to something else than libc */
-	free(argb);
+	WebPFree(argb);
 	gdFree(temp);
 	im->saveAlphaFlag = 1;
 	return im;


### PR DESCRIPTION
According to Google's spec, "The code that calls any of these functions must delete the data buffer (uint8_t*) returned by these functions with WebPFree()."
Using free() instead was causing heap corruption crashes for me (Windows MSVC 2019 compile)