### PR TITLE
Fix #847: enable back GD_BICUBIC* interpolation methods

### DIFF
--- a/src/gd_interpolation.c
+++ b/src/gd_interpolation.c
@@ -2257,6 +2257,11 @@ BGD_DECLARE(int) gdImageSetInterpolationMethod(gdImagePtr im, gdInterpolationMet
 		case GD_BESSEL:
 			im->interpolation = filter_bessel;
 			break;
+		case GD_BICUBIC_FIXED:
+		case GD_BICUBIC:
+			/* no interpolation as gdImageScale calls a dedicated function */
+			im->interpolation = NULL;
+			break;
 		case GD_BLACKMAN:
 			im->interpolation = filter_blackman;
 			break;

--- a/tests/gdimagesetinterpolationmethod/.gitignore
+++ b/tests/gdimagesetinterpolationmethod/.gitignore
@@ -1,1 +1,2 @@
 /github_bug_00584
+/github_bug_00847

--- a/tests/gdimagesetinterpolationmethod/CMakeLists.txt
+++ b/tests/gdimagesetinterpolationmethod/CMakeLists.txt
@@ -1,5 +1,6 @@
 LIST(APPEND TESTS_FILES
 	github_bug_00584
+	github_bug_00847
 )
 
 ADD_GD_TESTS()

--- a/tests/gdimagesetinterpolationmethod/Makemodule.am
+++ b/tests/gdimagesetinterpolationmethod/Makemodule.am
@@ -1,5 +1,6 @@
 libgd_test_programs += \
-	gdimagesetinterpolationmethod/github_bug_00584
+	gdimagesetinterpolationmethod/github_bug_00584 \
+	gdimagesetinterpolationmethod/github_bug_00847
 
 EXTRA_DIST += \
 	gdimagesetinterpolationmethod/CMakeLists.txt

--- a/tests/gdimagesetinterpolationmethod/github_bug_00847.c
+++ b/tests/gdimagesetinterpolationmethod/github_bug_00847.c
@@ -1,0 +1,12 @@
+#include "gd.h"
+#include "gdtest.h"
+
+int main()
+{
+  gdImagePtr im;
+  im = gdImageCreate(1, 1);
+  gdTestAssert(gdImageSetInterpolationMethod(im, GD_BICUBIC_FIXED) != 0);
+  gdTestAssert(gdImageGetInterpolationMethod(im) == GD_BICUBIC_FIXED);
+  gdImageDestroy(im);
+  return gdNumFailures();
+}


### PR DESCRIPTION
I made the PR for the GD-2.3 branch, as 2.3.3 is the version with the regression.