### PR TITLE
Fix #855: crash in gdImageClone after running gdImageFilledPolygon

### DIFF
--- a/src/gd.c
+++ b/src/gd.c
@@ -2940,7 +2940,7 @@ BGD_DECLARE(gdImagePtr) gdImageClone (gdImagePtr src) {
 	}
 
 	if (src->polyAllocated > 0 && overflow2(sizeof(int), src->polyAllocated) == 0) {
-		dst->polyInts = (int *) gdMalloc (sizeof (int) * src->polyAllocated);
+		dst->polyInts = gdMalloc (sizeof (int) * src->polyAllocated);
 		dst->polyAllocated = src->polyAllocated;
 		for (i = 0; i < src->polyAllocated; i++) {
 			dst->polyInts[i] = src->polyInts[i];

--- a/src/gd.c
+++ b/src/gd.c
@@ -2939,7 +2939,8 @@ BGD_DECLARE(gdImagePtr) gdImageClone (gdImagePtr src) {
 		dst->tileColorMap[i] = src->tileColorMap[i];
 	}
 
-	if (src->polyAllocated > 0) {
+	if (src->polyAllocated > 0 && overflow2(sizeof(int), src->polyAllocated) == 0) {
+		dst->polyInts = (int *) gdMalloc (sizeof (int) * src->polyAllocated);
 		dst->polyAllocated = src->polyAllocated;
 		for (i = 0; i < src->polyAllocated; i++) {
 			dst->polyInts[i] = src->polyInts[i];

--- a/tests/gdimageclone/.gitignore
+++ b/tests/gdimageclone/.gitignore
@@ -1,2 +1,3 @@
 /bug00300
 /style
+/polyInts

--- a/tests/gdimageclone/CMakeLists.txt
+++ b/tests/gdimageclone/CMakeLists.txt
@@ -1,6 +1,7 @@
 LIST(APPEND TESTS_FILES
 	bug00300
 	style
+	polyInts
 )
 
 ADD_GD_TESTS()

--- a/tests/gdimageclone/Makemodule.am
+++ b/tests/gdimageclone/Makemodule.am
@@ -1,6 +1,7 @@
 libgd_test_programs += \
 	gdimageclone/bug00300 \
-	gdimageclone/style
+	gdimageclone/style \
+	gdimageclone/polyInts
 
 EXTRA_DIST += \
 	gdimageclone/CMakeLists.txt

--- a/tests/gdimageclone/polyInts.c
+++ b/tests/gdimageclone/polyInts.c
@@ -2,6 +2,7 @@
  * Cloning polyInts without crashing
  */
 
+#include <string.h>
 #include "gd.h"
 #include "gdtest.h"
 

--- a/tests/gdimageclone/polyInts.c
+++ b/tests/gdimageclone/polyInts.c
@@ -1,0 +1,31 @@
+/**
+ * Cloning polyInts without crashing
+ */
+
+#include "gd.h"
+#include "gdtest.h"
+
+
+int main()
+{
+	gdImagePtr im, clone;
+	gdPoint pts[] = { {5, 5}, {50, 8}, {80, 4}, {85, 50}, {10, 60} };
+
+	im = gdImageCreateTrueColor(100, 100);
+	gdImageFilledPolygon(im, pts, 3, gdTrueColor(255, 0, 0));
+	clone = gdImageClone(im);
+
+	gdTestAssert(clone != NULL);
+	gdTestAssert(clone->polyAllocated == im->polyAllocated);
+	gdTestAssert(clone->polyInts != NULL);
+	gdTestAssert(!memcmp(clone->polyInts, im->polyInts, clone->polyAllocated * sizeof(clone->polyInts[0])));
+
+	/* test for reallocating clone->polyInts with glImageFilledPolygon */
+	gdImageFilledPolygon(clone, pts, 5, gdTrueColor(255, 0, 255));
+	gdTestAssert(clone->polyAllocated >= 5);
+
+	gdImageDestroy(clone);
+	gdImageDestroy(im);
+
+	return gdNumFailures();
+}


### PR DESCRIPTION
I made the PR for [#855](https://github.com/libgd/libgd/issues/855#issue-1501289624).  The overflow check is also included. 
Similar to the ```style``` allocation fix(https://github.com/libgd/libgd/commit/a93eac0e843148dc2d631c3ba80af17e9c8c860f), return ```dst``` instead of ```NULL``` even if the overflow check fails.


