### PR TITLE
Add missing static qualifiers

### DIFF
--- a/src/gd.c
+++ b/src/gd.c
@@ -2038,19 +2038,6 @@ strlen16 (unsigned short *s)
 	}
 	return len;
 }
-
-#ifndef HAVE_LSQRT
-/* If you don't have a nice square root function for longs, you can use
-   ** this hack
- */
-long
-lsqrt (long n)
-{
-	long result = (long) sqrt ((double) n);
-	return result;
-}
-#endif
-
 /* s and e are integers modulo 360 (degrees), with 0 degrees
    being the rightmost extreme and degrees changing clockwise.
    cx and cy are the center in pixels; w and h are the horizontal

--- a/src/gd.c
+++ b/src/gd.c
@@ -73,7 +73,7 @@ extern const int gdSinT[];
  * Group: Error Handling
  */
 
-void gd_stderr_error(int priority, const char *format, va_list args)
+static void gd_stderr_error(int priority, const char *format, va_list args)
 {
 	switch (priority) {
 	case GD_ERROR:

--- a/src/gd_interpolation.c
+++ b/src/gd_interpolation.c
@@ -294,7 +294,7 @@ static double filter_blackman(const double x, const double support)
 	return (0.42f+0.5f*(double)cos(M_PI*x)+0.08f*(double)cos(2.0f*M_PI*x));
 }
 
-double filter_linear(const double x, const double support) {
+static double filter_linear(const double x, const double support) {
 	ARG_NOT_USED(support);
 	double ax = fabs(x);
 	if (ax < 1.0f) {
@@ -704,7 +704,7 @@ static int getPixelInterpolateWeight(gdImagePtr im, const double x, const double
  * See also:
  *  <gdSetInterpolationMethod>
  */
-int getPixelInterpolated(gdImagePtr im, const double x, const double y, const int bgColor)
+static int getPixelInterpolated(gdImagePtr im, const double x, const double y, const int bgColor)
 {
 	const int xi=(int)(x);
 	const int yi=(int)(y);
@@ -1908,7 +1908,7 @@ BGD_DECLARE(gdImagePtr) gdImageRotateInterpolated(const gdImagePtr src, const fl
 	r->height = CLAMP(y1, c1y, c2y) - r->y + 1;
 }
 
-void gdDumpRect(const char *msg, gdRectPtr r)
+static void gdDumpRect(const char *msg, gdRectPtr r)
 {
 	printf("%s (%i, %i) (%i, %i)\n", msg, r->x, r->y, r->width, r->height);
 }

--- a/src/gd_jpeg.c
+++ b/src/gd_jpeg.c
@@ -242,7 +242,7 @@ BGD_DECLARE(void *) gdImageJpegPtr(gdImagePtr im, int *size, int quality)
 	return rv;
 }
 
-void jpeg_gdIOCtx_dest(j_compress_ptr cinfo, gdIOCtx *outfile);
+static void jpeg_gdIOCtx_dest(j_compress_ptr cinfo, gdIOCtx *outfile);
 
 /*
   Function: gdImageJpegCtx
@@ -536,7 +536,7 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromJpegPtrEx(int size, void *data, int ign
 	return im;
 }
 
-void jpeg_gdIOCtx_src(j_decompress_ptr cinfo, gdIOCtx *infile);
+static void jpeg_gdIOCtx_src(j_decompress_ptr cinfo, gdIOCtx *infile);
 
 static int CMYKToRGB(int c, int m, int y, int k, int inverted);
 
@@ -900,7 +900,7 @@ typedef my_source_mgr *my_src_ptr;
  * before any data is actually read.
  */
 
-void init_source(j_decompress_ptr cinfo)
+static void init_source(j_decompress_ptr cinfo)
 {
 	my_src_ptr src = (my_src_ptr)cinfo->src;
 
@@ -947,7 +947,7 @@ void init_source(j_decompress_ptr cinfo)
 
 #define END_JPEG_SEQUENCE "\r\n[*]--:END JPEG:--[*]\r\n"
 
-boolean fill_input_buffer(j_decompress_ptr cinfo)
+static boolean fill_input_buffer(j_decompress_ptr cinfo)
 {
 	my_src_ptr src = (my_src_ptr)cinfo->src;
 	/* 2.0.12: signed size. Thanks to Geert Jansen */
@@ -1002,7 +1002,7 @@ boolean fill_input_buffer(j_decompress_ptr cinfo)
  * buffer is the application writer's problem.
  */
 
-void skip_input_data(j_decompress_ptr cinfo, long num_bytes)
+static void skip_input_data(j_decompress_ptr cinfo, long num_bytes)
 {
 	my_src_ptr src = (my_src_ptr)cinfo->src;
 
@@ -1038,7 +1038,7 @@ void skip_input_data(j_decompress_ptr cinfo, long num_bytes)
  * application must deal with any cleanup that should happen even
  * for error exit.
  */
-void term_source(j_decompress_ptr cinfo)
+static void term_source(j_decompress_ptr cinfo)
 {
 	(void)cinfo;
 }
@@ -1050,7 +1050,7 @@ void term_source(j_decompress_ptr cinfo)
  * for closing it after finishing decompression.
  */
 
-void jpeg_gdIOCtx_src(j_decompress_ptr cinfo, gdIOCtx *infile)
+static void jpeg_gdIOCtx_src(j_decompress_ptr cinfo, gdIOCtx *infile)
 {
 	my_src_ptr src;
 
@@ -1100,7 +1100,7 @@ typedef my_destination_mgr *my_dest_ptr;
  * before any data is actually written.
  */
 
-void init_destination(j_compress_ptr cinfo)
+static void init_destination(j_compress_ptr cinfo)
 {
 	my_dest_ptr dest = (my_dest_ptr)cinfo->dest;
 
@@ -1137,7 +1137,7 @@ void init_destination(j_compress_ptr cinfo)
  * write it out when emptying the buffer externally.
  */
 
-boolean empty_output_buffer(j_compress_ptr cinfo)
+static boolean empty_output_buffer(j_compress_ptr cinfo)
 {
 	my_dest_ptr dest = (my_dest_ptr)cinfo->dest;
 
@@ -1161,7 +1161,7 @@ boolean empty_output_buffer(j_compress_ptr cinfo)
  * for error exit.
  */
 
-void term_destination(j_compress_ptr cinfo)
+static void term_destination(j_compress_ptr cinfo)
 {
 	my_dest_ptr dest = (my_dest_ptr) cinfo->dest;
 	int datacount = OUTPUT_BUF_SIZE - dest->pub.free_in_buffer;
@@ -1180,7 +1180,7 @@ void term_destination(j_compress_ptr cinfo)
  * for closing it after finishing compression.
  */
 
-void jpeg_gdIOCtx_dest(j_compress_ptr cinfo, gdIOCtx *outfile)
+static void jpeg_gdIOCtx_dest(j_compress_ptr cinfo, gdIOCtx *outfile)
 {
 	my_dest_ptr dest;
 

--- a/src/gd_rotate.c
+++ b/src/gd_rotate.c
@@ -18,7 +18,7 @@
 typedef int (BGD_STDCALL *FuncPtr)(gdImagePtr, int, int);
 
 #define ROTATE_DEG2RAD  3.1415926535897932384626433832795/180
-void gdImageSkewX (gdImagePtr dst, gdImagePtr src, int uRow, int iOffset, double dWeight, int clrBack, int ignoretransparent)
+static void gdImageSkewX (gdImagePtr dst, gdImagePtr src, int uRow, int iOffset, double dWeight, int clrBack, int ignoretransparent)
 {
 	int i, r, g, b, a, clrBackR, clrBackG, clrBackB, clrBackA;
 	FuncPtr f;
@@ -126,7 +126,7 @@ void gdImageSkewX (gdImagePtr dst, gdImagePtr src, int uRow, int iOffset, double
 	}
 }
 
-void gdImageSkewY (gdImagePtr dst, gdImagePtr src, int uCol, int iOffset, double dWeight, int clrBack, int ignoretransparent)
+static void gdImageSkewY (gdImagePtr dst, gdImagePtr src, int uCol, int iOffset, double dWeight, int clrBack, int ignoretransparent)
 {
 	int i, iYPos=0, r, g, b, a;
 	FuncPtr f;

--- a/src/gd_tiff.c
+++ b/src/gd_tiff.c
@@ -92,7 +92,7 @@ tiff_handle;
          tiff (assuming one already exists)
 */
 
-tiff_handle * new_tiff_handle(gdIOCtx *g)
+static tiff_handle * new_tiff_handle(gdIOCtx *g)
 {
 	tiff_handle * t;
 
@@ -223,7 +223,7 @@ static void tiff_unmapproc(thandle_t h, tdata_t d, toff_t o)
  *  out:      the stream where to write
  *  bitDepth: depth in bits of each pixel
  */
-void tiffWriter(gdImagePtr image, gdIOCtx *out, int bitDepth)
+static void tiffWriter(gdImagePtr image, gdIOCtx *out, int bitDepth)
 {
 	int x, y;
 	int i;

--- a/src/gd_wbmp.c
+++ b/src/gd_wbmp.c
@@ -74,7 +74,7 @@
  * ---------
  * Wrapper around gdPutC for use with writewbmp
  */
-void gd_putout(int i, void *out)
+static void gd_putout(int i, void *out)
 {
 	gdPutC(i, (gdIOCtx *)out);
 }
@@ -83,7 +83,7 @@ void gd_putout(int i, void *out)
  * --------
  * Wrapper around gdGetC for use with readwbmp
  */
-int gd_getin(void *in)
+static int gd_getin(void *in)
 {
 	return (gdGetC((gdIOCtx *)in));
 }

--- a/src/gdcmpgif.c
+++ b/src/gdcmpgif.c
@@ -15,7 +15,7 @@
 	basis image that must be loaded quickly. The .gd format
 	is not intended to be a general-purpose format. */
 
-void CompareImages(char *msg, gdImagePtr im1, gdImagePtr im2);
+static void CompareImages(char *msg, gdImagePtr im1, gdImagePtr im2);
 
 
 int main(int argc, char **argv)
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
 	return 0;
 }
 
-void CompareImages(char *msg, gdImagePtr im1, gdImagePtr im2)
+static void CompareImages(char *msg, gdImagePtr im1, gdImagePtr im2)
 {
 	int cmpRes;
 

--- a/src/gdft.c
+++ b/src/gdft.c
@@ -263,7 +263,7 @@ extern int any2eucjp (char *, const char *, unsigned int);
 /* Fonts can be used across multiple images */
 
 /* 2.0.16: thread safety (the font cache is shared) */
-gdMutexDeclare (gdFontCacheMutex);
+static gdMutexDeclare (gdFontCacheMutex);
 static gdCache_head_t *fontCache;
 static FT_Library library;
 

--- a/src/gdfx.c
+++ b/src/gdfx.c
@@ -388,7 +388,7 @@ gdImageSquareToCircle (gdImagePtr im, int radius)
 returns new colour for centre pixel
 */
 
-int
+static int
 gdImageSubSharpen (int pc, int c, int nc, float inner_coeff, float
                    outer_coeff)
 {


### PR DESCRIPTION
Suboptimal code is generated because multiple functions lack of static qualifier . This PR fixes most