### PR TITLE
Fix "Run tests" step for windows mingw CI

### DIFF
--- a/.github/workflows/ci_windows_mingw.yml
+++ b/.github/workflows/ci_windows_mingw.yml
@@ -74,6 +74,6 @@ jobs:
       working-directory: ${{github.workspace}}
       run: |
         mkdir tmp
-        export TMP=${{github.workspace}}\\tmp
+        export TMP="$PWD/tmp"
         export CTEST_OUTPUT_ON_FAILURE=1
         ctest


### PR DESCRIPTION
~Use script syntax for `command.com` instead of `sh`.~
Fix construction of `TMP` path.