### PR TITLE
Skip failure tests on riscv64.

### DIFF
--- a/tests/gdimagecopyresampled/bug00201.c
+++ b/tests/gdimagecopyresampled/bug00201.c
@@ -45,7 +45,7 @@ int main()
 
 // Rounding issue, won't fix as it only happens on mingw 32bit.
 // __aarch64__/graviton. It fails within the CI while outside is 100% success over 100s builds&runs
-#if defined(__MINGW32__) || defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__MINGW32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(__riscv)
     return 77;
 #endif 
     background = blank_image(DEST_WIDTH,DEST_HEIGHT);

--- a/tests/gdimagegrayscale/basic.c
+++ b/tests/gdimagegrayscale/basic.c
@@ -12,7 +12,7 @@ int main()
 	char *path;
 // Rounding issue, won't fix as it only happens on mingw 32bit.
 // __aarch64__/graviton. It fails within the CI while outside is 100% success over 100s builds&runs
-#if defined(__MINGW32__) || defined(__aarch64__) || defined(_M_ARM64)
+#if defined(__MINGW32__) || defined(__aarch64__) || defined(_M_ARM64) || defined(__riscv)
     return 77;
 #endif 
 	fp = gdTestFileOpen2("gdimagegrayscale", "basic.png");


### PR DESCRIPTION
These two tests don't fit riscv64 and therefore fail at build time, hopefully skipped.
[This](https://openkoji.iscas.ac.cn/koji/buildinfo?buildID=131383) can prove that the modification is valid.