### PR TITLE
cmake: add missing <stdlib.h> for exit to TestForHighBitCharacters

### DIFF
--- a/cmake/modules/TestForHighBitCharacters.c
+++ b/cmake/modules/TestForHighBitCharacters.c
@@ -18,6 +18,7 @@
  */
 
 #include <ctype.h>
+#include <stdlib.h>
 #if ((' ' & 0x0FF) == 0x020)
 # define ISLOWER(c) ('a' <= (c) && (c) <= 'z')
 # define TOUPPER(c) (ISLOWER(c) ? 'A' + ((c) - 'a') : (c))


### PR DESCRIPTION
The test will wrongly fail otherwise with newer stricter compilers that default to rejecting implicit function declarations.