### PR TITLE
imageclone fix leaks when tile and/or brush are set.

### DIFF
--- a/src/gd.c
+++ b/src/gd.c
@@ -244,6 +244,7 @@ BGD_DECLARE(gdImagePtr) gdImageCreate (int sx, int sy)
 	im->res_y = GD_RESOLUTION;
 	im->interpolation = NULL;
 	im->interpolation_id = GD_BILINEAR_FIXED;
+	im->cloned = 0;
 	return im;
 }
 
@@ -353,6 +354,7 @@ BGD_DECLARE(gdImagePtr) gdImageCreateTrueColor (int sx, int sy)
 	im->res_y = GD_RESOLUTION;
 	im->interpolation = NULL;
 	im->interpolation_id = GD_BILINEAR_FIXED;
+	im->cloned = 0;
 	return im;
 }
 
@@ -387,6 +389,7 @@ BGD_DECLARE(gdImagePtr) gdImageCreateTrueColor (int sx, int sy)
 BGD_DECLARE(void) gdImageDestroy (gdImagePtr im)
 {
 	int i;
+
 	if (im->pixels) {
 		for (i = 0; (i < im->sy); i++) {
 			gdFree (im->pixels[i]);
@@ -404,6 +407,14 @@ BGD_DECLARE(void) gdImageDestroy (gdImagePtr im)
 	}
 	if (im->style) {
 		gdFree (im->style);
+	}
+	if (im->cloned) {
+		if (im->brush) {
+			gdImageDestroy(im->brush);
+		}
+		if (im->tile) {
+			gdImageDestroy(im->tile);
+		}
 	}
 	gdFree (im);
 }
@@ -2907,6 +2918,7 @@ BGD_DECLARE(gdImagePtr) gdImageClone (gdImagePtr src) {
 
 	dst->interpolation_id = src->interpolation_id;
 	dst->interpolation    = src->interpolation;
+	dst->cloned = 1;
 
 	if (src->brush) {
 		dst->brush = gdImageClone(src->brush);

--- a/src/gd.h
+++ b/src/gd.h
@@ -506,6 +506,8 @@ typedef struct gdImageStruct {
 	int paletteQuantizationMaxQuality;
 	gdInterpolationMethod interpolation_id;
 	interpolation_method interpolation;
+
+	int cloned;
 }
 gdImage;
 

--- a/tests/gdimageclone/CMakeLists.txt
+++ b/tests/gdimageclone/CMakeLists.txt
@@ -2,6 +2,7 @@ LIST(APPEND TESTS_FILES
 	bug00300
 	style
 	polyInts
+	tilebrush
 )
 
 ADD_GD_TESTS()

--- a/tests/gdimageclone/tilebrush.c
+++ b/tests/gdimageclone/tilebrush.c
@@ -1,0 +1,24 @@
+#include "gd.h"
+#include "gdtest.h"
+
+
+int main()
+{
+    gdImagePtr im, tile, brush, clone;
+
+    im = gdImageCreate(50, 50);
+    tile = gdImageCreateTrueColor(10, 10);
+    brush = gdImageCreate(25, 25);
+    gdImageColorTransparent(tile, 0xFFFFFF);
+    gdImageSetTile(im, tile);
+    gdImageSetTile(im, brush);
+
+    clone = gdImageClone(im);
+
+    gdImageDestroy(clone);
+    gdImageDestroy(im);
+    gdImageDestroy(brush);
+    gdImageDestroy(tile);
+
+    return 0;
+}


### PR DESCRIPTION
those are cloned themselves which make things complicated to track to release manually thus taking care of cloned parts internally.