### PR TITLE
Check libavif API return values, if available

### DIFF
--- a/src/gd_avif.c
+++ b/src/gd_avif.c
@@ -546,12 +546,11 @@ static avifBool _gdImageAvifCtx(gdImagePtr im, gdIOCtx *outfile, int quality, in
 	// Note that MATRIX_COEFFICIENTS_IDENTITY enables lossless conversion from RGB to YUV.
 
 	avifImage *avifIm = avifImageCreate(gdImageSX(im), gdImageSY(im), 8, subsampling);
-#if AVIF_VERSION >= 1000000
 	if (avifIm == NULL) {
 		gd_error("avif error - Creating image failed\n");
 		goto cleanup;
 	}
-#endif
+
 	avifIm->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
 	avifIm->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
 	avifIm->matrixCoefficients = lossless ? AVIF_MATRIX_COEFFICIENTS_IDENTITY : AVIF_MATRIX_COEFFICIENTS_BT709;
@@ -591,12 +590,11 @@ static avifBool _gdImageAvifCtx(gdImagePtr im, gdIOCtx *outfile, int quality, in
 	// Encode the image in AVIF format.
 
 	encoder = avifEncoderCreate();
-#if AVIF_VERSION >= 1000000
 	if (encoder == NULL) {
 		gd_error("avif error - Creating encoder failed\n");
 		goto cleanup;
 	}
-#endif
+
 	int quantizerQuality = quality == QUALITY_DEFAULT ?
 		QUANTIZER_DEFAULT : quality2Quantizer(quality);
 

--- a/src/gd_avif.c
+++ b/src/gd_avif.c
@@ -402,7 +402,13 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromAvifCtx (gdIOCtx *ctx)
 	// (While AVIF image pixel depth can be 8, 10, or 12 bits, GD truecolor images are 8-bit.)
 	avifRGBImageSetDefaults(&rgb, decoder->image);
 	rgb.depth = 8;
+#if AVIF_VERSION >= 1000000
+	result = avifRGBImageAllocatePixels(&rgb);
+	if (isAvifError(result, "Allocating RGB pixels failed"))
+		goto cleanup;
+#else
 	avifRGBImageAllocatePixels(&rgb);
+#endif
 
 	result = avifImageYUVToRGB(decoder->image, &rgb);
 	if (isAvifError(result, "Conversion from YUV to RGB failed"))
@@ -540,14 +546,25 @@ static avifBool _gdImageAvifCtx(gdImagePtr im, gdIOCtx *outfile, int quality, in
 	// Note that MATRIX_COEFFICIENTS_IDENTITY enables lossless conversion from RGB to YUV.
 
 	avifImage *avifIm = avifImageCreate(gdImageSX(im), gdImageSY(im), 8, subsampling);
-
+#if AVIF_VERSION >= 1000000
+	if (avifIm == NULL) {
+		gd_error("avif error - Creating image failed\n");
+		goto cleanup;
+	}
+#endif
 	avifIm->colorPrimaries = AVIF_COLOR_PRIMARIES_BT709;
 	avifIm->transferCharacteristics = AVIF_TRANSFER_CHARACTERISTICS_SRGB;
 	avifIm->matrixCoefficients = lossless ? AVIF_MATRIX_COEFFICIENTS_IDENTITY : AVIF_MATRIX_COEFFICIENTS_BT709;
 
 	avifRGBImageSetDefaults(&rgb, avifIm);
 	// this allocates memory, and sets rgb.rowBytes and rgb.pixels.
+#if AVIF_VERSION >= 1000000
+	result = avifRGBImageAllocatePixels(&rgb);
+	if (isAvifError(result, "Allocating RGB pixels failed"))
+		goto cleanup;
+#else
 	avifRGBImageAllocatePixels(&rgb);
+#endif
 
 	// Parse RGB data from the GD image, and copy it into the AVIF RGB image.
 	// Convert 7-bit GD alpha channel values to 8-bit AVIF values.
@@ -574,6 +591,12 @@ static avifBool _gdImageAvifCtx(gdImagePtr im, gdIOCtx *outfile, int quality, in
 	// Encode the image in AVIF format.
 
 	encoder = avifEncoderCreate();
+#if AVIF_VERSION >= 1000000
+	if (encoder == NULL) {
+		gd_error("avif error - Creating encoder failed\n");
+		goto cleanup;
+	}
+#endif
 	int quantizerQuality = quality == QUALITY_DEFAULT ?
 		QUANTIZER_DEFAULT : quality2Quantizer(quality);
 


### PR DESCRIPTION
Prior to libavif 1.1.0, `avifAlloc()` was infallible (it called `abort()` on OOM conditions); thus, several API functions which used `avifAlloc()` did not report failure.  That changed as of libavif 1.0.0[1], so checking and handling failure conditions can now be done. However, due to `avifAlloc()` being fallible as of libavif 1.1.0, this error checking and handling is mandatory to avoid more serious issues.

[1] <https://github.com/AOMediaCodec/libavif/blob/eb02b2ec52df5c0f50b71fbc51321c5ce435aaca/CHANGELOG.md?plain=1#L273-L281>