### PR TITLE
Fix macOS CI job

### DIFF
--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -58,14 +58,14 @@ jobs:
           pkg-config --libs libpng
           pkg-config --libs --cflags libpng16
           pkg-config --libs libpng16
-          ls /usr/local/Cellar/libpng/$LIBPNG_VERSION/
-          ls /usr/local/Cellar/libpng/$LIBPNG_VERSION/lib/
+          ls /opt/homebrew/Cellar/libpng/$LIBPNG_VERSION/
+          ls /opt/homebrew/Cellar/libpng/$LIBPNG_VERSION/lib/
           ${{github.workspace}}/.github/scripts/removemono.sh
 
       - name: Configure CMake
         run:  cmake -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1 -DENABLE_WEBP=1
               -DENABLE_TIFF=1  -DENABLE_GD_FORMATS=1 -DENABLE_CPP=0 -DENABLE_HEIF=1 -D CMAKE_PREFIX_PATH=/usr/local
-              -DBUILD_TEST=1 -DVERBOSE_MAKEFILE=1 -DPNG_PNG_INCLUDE_DIR=/usr/local/Cellar/libpng/${{ env.LIBPNG_VERSION }}/include -DPNG_PNG_LIBRARY_DIR=/usr/local/Cellar/libpng/${{ env.LIBPNG_VERSION }}/lib -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+              -DBUILD_TEST=1 -DVERBOSE_MAKEFILE=1 -DPNG_PNG_INCLUDE_DIR=/opt/homebrew/Cellar/libpng/${{ env.LIBPNG_VERSION }}/include -DPNG_PNG_LIBRARY_DIR=/usr/local/Cellar/libpng/${{ env.LIBPNG_VERSION }}/lib -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel 4


### PR DESCRIPTION
As can be seen from the pkg-config output, libpng apparently no longer lives in /usr/local but rather in /opt/homebrew.  We apply a hard-coded quick fix.