### PR TITLE
Fix HEIF image handling with uninitialized library

### DIFF
--- a/src/gd.h
+++ b/src/gd.h
@@ -382,6 +382,10 @@ typedef const char *gdHeifChroma;
 #define GD_HEIF_CHROMA_422 "422"
 #define GD_HEIF_CHROMA_444 "444"
 
+BGD_DECLARE(int) gdHeifInit();
+
+BGD_DECLARE(void) gdHeifDeinit();
+
 /* define struct with name and func ptr and add it to gdImageStruct gdInterpolationMethod interpolation; */
 
 /* Interpolation function ptr */

--- a/src/gdhelpers.h
+++ b/src/gdhelpers.h
@@ -12,6 +12,24 @@ extern "C" {
 #include <stdlib.h>
 #endif /* _WIN32_WCE */
 
+#if defined(_WIN32) || defined(CYGWIN) || defined(_WIN32_WCE)
+# ifdef __GNUC__
+#  if (__STDC_VERSION__ >= 201112L)
+#   define BGD_THREAD_LOCAL _Thread_local
+#  else
+#   define BGD_THREAD_LOCAL __thread
+#  endif
+# else
+#  define BGD_THREAD_LOCAL __declspec(thread)
+# endif
+#else
+# if (__STDC_VERSION__ >= 201112L)
+#  define BGD_THREAD_LOCAL _Thread_local
+# else
+#  define BGD_THREAD_LOCAL __thread
+# endif
+#endif
+
 	/* TBB: strtok_r is not universal; provide an implementation of it. */
 
 	char *gd_strtok_r(char *s, const char *sep, char **state);

--- a/tests/heif/heif_read.c
+++ b/tests/heif/heif_read.c
@@ -1,6 +1,5 @@
 /**
- * Simple test case that confirms the failure of using `gdImageCreateFromHeif`
- * with a NULL pointer.
+ * Simple test case that checks reading images using `gdImageCreateFromHeif`.
  */
 
 


### PR DESCRIPTION
From version `1.13.0` of libheif the library needs to be initialized to load its plugins and it has to be done by any consumer of the library, including libgd, I've forgot to add such thing. This PR adds two function for it, `gdHeifInit` and `gdHeifDeinit`, the former gets called by any method that handles HEIF images and the latter is used for cleanup. Fixes #889.
