### PR TITLE
Fix #899: Test suite refers to nonexistent "gdmatrix" directory

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -74,6 +74,7 @@ include gdimagestringup/Makemodule.am
 include gdimagestringup16/Makemodule.am
 include gdimagetruecolortopalette/Makemodule.am
 include gdinterpolatedscale/Makemodule.am
+include gdmatrix/Makemodule.am
 include gdnewfilectx/Makemodule.am
 include gdtest/Makemodule.am
 include gdtiled/Makemodule.am

--- a/tests/gdmatrix/Makemodule.am
+++ b/tests/gdmatrix/Makemodule.am
@@ -1,0 +1,5 @@
+libgd_test_programs += \
+	gdmatrix/bug00402
+
+EXTRA_DIST += \
+	gdmatrix/CMakeLists.txt


### PR DESCRIPTION
We need to support all tests with autotools, what is particularly relevant for our release tarballs which also need to ship the CMakeLists.txt files of all test directories.