### PR TITLE
Drop self-hosted Graviton job from CI

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -30,13 +30,6 @@ jobs:
               cc: "clang-12",
               cxx: "clang-cpp-12"
             }
-          - {
-              name: "Ubuntu Graviton GCC",
-              os: [self-hosted, Linux, ARM64, graviton],
-              cc: "gcc",
-              cxx: "g++",
-              cflags: "-march=armv8.2-a+fp16+rcpc+dotprod+crypto+sve -mtune=neoverse-n1"
-            }
 
     name: ${{ matrix.config.name }}
     defaults:


### PR DESCRIPTION
It doesn't make sense to have CI waiting a day until it fails the job. Apparently, that runner is no longer available.  If that changes, we can re-add the job.