### PR TITLE
Run tests for clang CI job, too

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -160,7 +160,6 @@ jobs:
         run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}} --parallel 4
 
       - name: Test
-        if: contains(matrix.config.cc, 'gcc')
         working-directory: ${{github.workspace}}/build
         run: |
           export TMP=${{runner.temp}}


### PR DESCRIPTION
There doesn't seem to be a particular to not run the tests, so we run them.