### PR TITLE
Improve build time of Windows CI jobs

### DIFF
--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -68,4 +68,4 @@ jobs:
           echo %TEMP%
           set PATH=${{github.workspace}}\vcpkgusr\${{ matrix.arch }}-windows\bin;%PATH%
           set CTEST_OUTPUT_ON_FAILURE=1
-          nmake test
+          ctest -C ${{env.BUILD_TYPE}}

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Configure CMake
         # vcpkg libde265 fails on arm64 and match prefix
         if: matrix.arch == 'amd64_arm64'
-        run:  cmake -D CMAKE_GENERATOR="Visual Studio 17 2022" -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
+        run:  cmake -D CMAKE_GENERATOR="Visual Studio 17 2022" -A ARM64 -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
               -DENABLE_GD_FORMATS=1 -DENABLE_TIFF=1 -DBUILD_TEST=1
               -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
               -DCMAKE_LIBRARY_PATH=${{github.workspace}}\vcpkgusr\arm64-windows\lib
@@ -47,7 +47,7 @@ jobs:
 
       - name: Configure CMake
         if: matrix.arch != 'amd64_arm64'
-        run:  cmake -D CMAKE_GENERATOR="Visual Studio 17 2022" -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
+        run:  cmake -D CMAKE_GENERATOR="Visual Studio 17 2022" -A ${{ matrix.arch == 'x64' && 'x64' || 'Win32' }} -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
                -DENABLE_GD_FORMATS=1 -DENABLE_TIFF=1 -DENABLE_HEIF=1
               -DBUILD_TEST=1 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
               -DCMAKE_LIBRARY_PATH=${{github.workspace}}\vcpkgusr\${{ matrix.arch }}-windows\lib

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Configure CMake
         # vcpkg libde265 fails on arm64 and match prefix
         if: matrix.arch == 'amd64_arm64'
-        run:  cmake -D CMAKE_GENERATOR="Visual Studio 17 2022" -A ARM64 -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
+        run:  cmake -D CMAKE_GENERATOR="Ninja" -A ARM64 -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
               -DENABLE_GD_FORMATS=1 -DENABLE_TIFF=1 -DBUILD_TEST=1
               -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
               -DCMAKE_LIBRARY_PATH=${{github.workspace}}\vcpkgusr\arm64-windows\lib
@@ -47,7 +47,7 @@ jobs:
 
       - name: Configure CMake
         if: matrix.arch != 'amd64_arm64'
-        run:  cmake -D CMAKE_GENERATOR="Visual Studio 17 2022" -A ${{ matrix.arch == 'x64' && 'x64' || 'Win32' }} -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
+        run:  cmake -D CMAKE_GENERATOR="Ninja" -A ${{ matrix.arch == 'x64' && 'x64' || 'Win32' }} -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
                -DENABLE_GD_FORMATS=1 -DENABLE_TIFF=1 -DENABLE_HEIF=1
               -DBUILD_TEST=1 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
               -DCMAKE_LIBRARY_PATH=${{github.workspace}}\vcpkgusr\${{ matrix.arch }}-windows\lib

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build
         run: |
          cd ${{github.workspace}}/build
-         cmake --build . --config ${{env.BUILD_TYPE}} --parallel %NUMBER_OF_PROCESSORS%
+         cmake --build . --config ${{env.BUILD_TYPE}}
 
       - name: Tests
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Build
         run: |
          cd ${{github.workspace}}/build
-         cmake --build . --config ${{env.BUILD_TYPE}} --parallel 2
+         cmake --build . --config ${{env.BUILD_TYPE}} --parallel %NUMBER_OF_PROCESSORS%
 
       - name: Tests
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Configure CMake
         # vcpkg libde265 fails on arm64 and match prefix
         if: matrix.arch == 'amd64_arm64'
-        run:  cmake -D CMAKE_GENERATOR="NMake Makefiles" -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
+        run:  cmake -D CMAKE_GENERATOR="Visual Studio 17 2022" -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
               -DENABLE_GD_FORMATS=1 -DENABLE_TIFF=1 -DBUILD_TEST=1
               -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
               -DCMAKE_LIBRARY_PATH=${{github.workspace}}\vcpkgusr\arm64-windows\lib
@@ -47,7 +47,7 @@ jobs:
 
       - name: Configure CMake
         if: matrix.arch != 'amd64_arm64'
-        run:  cmake -D CMAKE_GENERATOR="NMake Makefiles" -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
+        run:  cmake -D CMAKE_GENERATOR="Visual Studio 17 2022" -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
                -DENABLE_GD_FORMATS=1 -DENABLE_TIFF=1 -DENABLE_HEIF=1
               -DBUILD_TEST=1 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
               -DCMAKE_LIBRARY_PATH=${{github.workspace}}\vcpkgusr\${{ matrix.arch }}-windows\lib
@@ -56,7 +56,7 @@ jobs:
       - name: Build
         run: |
          cd ${{github.workspace}}/build
-         nmake
+         cmake --build . --config ${{env.BUILD_TYPE}} --parallel 2
 
       - name: Tests
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Configure CMake
         # vcpkg libde265 fails on arm64 and match prefix
         if: matrix.arch == 'amd64_arm64'
-        run:  cmake -D CMAKE_GENERATOR="Ninja" -A ARM64 -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
+        run:  cmake -D CMAKE_GENERATOR="Ninja" -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
               -DENABLE_GD_FORMATS=1 -DENABLE_TIFF=1 -DBUILD_TEST=1
               -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
               -DCMAKE_LIBRARY_PATH=${{github.workspace}}\vcpkgusr\arm64-windows\lib
@@ -47,7 +47,7 @@ jobs:
 
       - name: Configure CMake
         if: matrix.arch != 'amd64_arm64'
-        run:  cmake -D CMAKE_GENERATOR="Ninja" -A ${{ matrix.arch == 'x64' && 'x64' || 'Win32' }} -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
+        run:  cmake -D CMAKE_GENERATOR="Ninja" -DENABLE_PNG=1 -DENABLE_FREETYPE=1 -DENABLE_JPEG=1
                -DENABLE_GD_FORMATS=1 -DENABLE_TIFF=1 -DENABLE_HEIF=1
               -DBUILD_TEST=1 -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
               -DCMAKE_LIBRARY_PATH=${{github.workspace}}\vcpkgusr\${{ matrix.arch }}-windows\lib


### PR DESCRIPTION
These take particularly long (about 90 to 120 seconds), presumably because NMake builds can't use parallel processing.  Thus we generate Visual Studio solutions which can be build in parallel.