### PR TITLE
Support HEIC image encoding with libkvazaar

### DIFF
--- a/src/gd_heif.c
+++ b/src/gd_heif.c
@@ -327,7 +327,8 @@ static int _gdImageHeifCtx(gdImagePtr im, gdIOCtx *outfile, int quality, gdHeifC
 		return GD_FALSE;
 	}
 
-	if (heif_get_version_number_major() >= 1 && heif_get_version_number_minor() >= 9) {
+	if (heif_get_version_number_major() >= 1 && heif_get_version_number_minor() >= 9
+	 && strncmp(heif_encoder_get_name(heif_enc), "kvazaar", strlen("kvazaar"))) {
 		err = heif_encoder_set_parameter_string(heif_enc, "chroma", chroma);
 		if (err.code != heif_error_Ok) {
 			gd_error("gd-heif invalid chroma subsampling parameter\n");


### PR DESCRIPTION
libheif currently supports x265 and kvazaar for encoding HEIC images; while the former is recommended, the latter has a more liberal license, and as such is an interesting alternative.  However, kvazaar apparently does not yet support changing the chroma subsampling, and as such, writing HEIC images fails.  We apply basically the same fix as for libheif < 1.9.0, where we just ignore the given chroma subsampling, and use whatever the encoder deems suitable (likely 420).

[1] <https://github.com/strukturag/libheif?tab=readme-ov-file#compiling>

---

Note that this fixes tests/heif/bug788 for me, and let's tests/heif/heif_im2im proceed (it now only fails due to pixel differences; likely that would happen with older libheif, too).

Also note that comparing the plugin name might be a bit brittle, but comparing the plugin ID might be too, and seems to require more ado, so maybe we're good comparing the name.

Since we support HEIF encoding not only with HEVC, but also with AV1, it seems to prudent to check whether the AV1 encoders supported by libheif (currently AOM, rav1e, and svt-av1), work as expected, or show similar limitations as kvazaar (chroma subsampling is supported by all three, but there may be other limitations).

cc @YakoYakoYokuYoku 