### PR TITLE
Avoid segfault of bug788

### DIFF
--- a/tests/heif/bug788.c
+++ b/tests/heif/bug788.c
@@ -24,6 +24,10 @@ int main () {
     data = gdImageHeifPtrEx(in, &size, 200, GD_HEIF_CODEC_HEVC, GD_HEIF_CHROMA_444);
 
     dst = gdImageCreateFromHeifPtr(size, data);
+    if (!gdTestAssert(dst != NULL)) {
+        gdImageDestroy(in);
+        return gdNumFailures();
+    }
     diff = gdImageCreateTrueColor(gdImageSX(dst), gdImageSY(dst));
     if (gdTestAssertMsg(dst != NULL, "cannot compare with NULL buffer")) {
         gdTestImageDiff(in, dst, diff, &result);


### PR DESCRIPTION
If the heif image can't be created for whatever reason, `dst` is `NULL` what causes a segfault when we try to access its dimensions.  We catch that with a test assertion, and bail out if that fails.