### PR TITLE
Join build and tests workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,7 @@
+# The main CI workflow which runs the individual workflows
+# and gathers their results in the workflow overview.
+# See <https://docs.github.com/en/actions/sharing-automations/reusing-workflows>
+
 name: CI build and test
 
 on:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI build and test
+
+on:
+  push:
+    branches: [master, GD-*]
+  pull_request:
+    branches: [master, GD-*]
+
+jobs:
+  ubuntu:
+    uses: ./.github/workflows/ci_ubuntu.yml
+  windows:
+    uses: ./.github/workflows/ci_windows.yml
+  macos:
+    uses: ./.github/workflows/ci_macos.yml
+  mingw:
+    uses: ./.github/workflows/ci_windows_mingw.yml

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -1,10 +1,6 @@
 name: CI macOS
 
-on:
-  push:
-    branches: [master, GD-*]
-  pull_request:
-    branches: [master, GD-*]
+on: workflow_call
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -1,10 +1,6 @@
 name: CI Ubuntu
 
-on:
-  push:
-    branches: [master, GD-*]
-  pull_request:
-    branches: [master, GD-*]
+on: workflow_call
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -1,10 +1,6 @@
 name: CI Windows
 
-on:
-  push:
-    branches: [master, GD-*]
-  pull_request:
-    branches: [master, GD-*]
+on: workflow_call
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/ci_windows_mingw.yml
+++ b/.github/workflows/ci_windows_mingw.yml
@@ -1,11 +1,7 @@
 name: CI Windows Mingw
 
 on:
-  push:
-    branches: [master, GD-*]
-  pull_request:
-    branches: [master, GD-*]
-
+  workflow_call:
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
As is, we have four individual workflows running for each push or pull request; while their results are gathered in the overview, they still have individual run IDs, and so navigating the results can be tedious. Maybe even worse, if jobs fail in multiple of these workflows, there are multiple email notifications about that, what is annoying.

Thus, we join the workflows, but still retain the individual workflow files.