### PR TITLE
Transparent support for writing 1bpp and 4bpp BMPs

### DIFF
--- a/src/gd_bmp.c
+++ b/src/gd_bmp.c
@@ -91,7 +91,7 @@ BGD_DECLARE(void *) gdImageBmpPtr(gdImagePtr im, int *size, int compression)
 	gdIOCtx *out = gdNewDynamicCtx(2048, NULL);
 	if (out == NULL) return NULL;
 	if (!_gdImageBmpCtx(im, out, compression))
-	rv = gdDPExtractData(out, size);
+		rv = gdDPExtractData(out, size);
 	else
 		rv = NULL;
 	out->gd_free(out);

--- a/src/gd_bmp.c
+++ b/src/gd_bmp.c
@@ -33,8 +33,8 @@
 #include "gd_errors.h"
 #include "bmp.h"
 
-static int compress_row(unsigned char *uncompressed_row, int length);
-static int build_rle_packet(unsigned char *row, int packet_type, int length, unsigned char *data);
+static int compress_row(unsigned char *uncompressed_row, int length, int ppbyte, int nibble);
+static int build_rle_packet(unsigned char *row, int packet_type, int length, unsigned char *data, int ppbyte, int nibble);
 
 static int bmp_read_header(gdIOCtxPtr infile, bmp_hdr_t *hdr);
 static int bmp_read_info(gdIOCtxPtr infile, bmp_info_t *info);
@@ -91,7 +91,7 @@ BGD_DECLARE(void *) gdImageBmpPtr(gdImagePtr im, int *size, int compression)
 	gdIOCtx *out = gdNewDynamicCtx(2048, NULL);
 	if (out == NULL) return NULL;
 	if (!_gdImageBmpCtx(im, out, compression))
-		rv = gdDPExtractData(out, size);
+	rv = gdDPExtractData(out, size);
 	else
 		rv = NULL;
 	out->gd_free(out);
@@ -152,6 +152,7 @@ BGD_DECLARE(void) gdImageBmpCtx(gdImagePtr im, gdIOCtxPtr out, int compression)
 
 static int _gdImageBmpCtx(gdImagePtr im, gdIOCtxPtr out, int compression)
 {
+	int bpp, ppbyte, compression_method;
 	int bitmap_size = 0, info_size, total_size, padding;
 	int i, row, xpos, pixel;
 	int error = 0;
@@ -179,7 +180,17 @@ static int _gdImageBmpCtx(gdImagePtr im, gdIOCtxPtr out, int compression)
 		}
 	}
 
-	bitmap_size = ((im->sx * (im->trueColor ? 24 : 8)) / 8) * im->sy;
+	if (im->trueColor) {
+		bpp = 24;
+	} else if (im->colorsTotal <= 2 && !compression) {
+		bpp = 1;
+	} else if (im->colorsTotal <= 16) {
+		bpp = 4;
+	} else {
+		bpp = 8;
+	}
+	ppbyte = 8 / bpp; /* for palette images */
+	bitmap_size = ((im->sx * bpp + 7) / 8) * im->sy;
 
 	/* 40 byte Windows v3 header */
 	info_size = BMP_WINDOWS_V3;
@@ -195,6 +206,8 @@ static int _gdImageBmpCtx(gdImagePtr im, gdIOCtxPtr out, int compression)
 	/* bitmap header + info header + data */
 	total_size = 14 + info_size + bitmap_size;
 
+	compression_method = (compression ? (bpp >= 8 ? BMP_BI_RLE8 : BMP_BI_RLE4) : BMP_BI_RGB);
+
 	/* write bmp header info */
 	gdPutBuf("BM", 2, out);
 	gdBMPPutInt(out, total_size);
@@ -207,8 +220,8 @@ static int _gdImageBmpCtx(gdImagePtr im, gdIOCtxPtr out, int compression)
 	gdBMPPutInt(out, im->sx); /* width */
 	gdBMPPutInt(out, im->sy); /* height */
 	gdBMPPutWord(out, 1); /* colour planes */
-	gdBMPPutWord(out, (im->trueColor ? 24 : 8)); /* bit count */
-	gdBMPPutInt(out, (compression ? BMP_BI_RLE8 : BMP_BI_RGB)); /* compression */
+	gdBMPPutWord(out, bpp); /* bit count */
+	gdBMPPutInt(out, compression_method); /* compression */
 	gdBMPPutInt(out, bitmap_size); /* image size */
 	gdBMPPutInt(out, 0); /* H resolution */
 	gdBMPPutInt(out, 0); /* V ressolution */
@@ -216,7 +229,11 @@ static int _gdImageBmpCtx(gdImagePtr im, gdIOCtxPtr out, int compression)
 	gdBMPPutInt(out, 0); /* important colours */
 
 	/* The line must be divisible by 4, else its padded with NULLs */
-	padding = ((int)(im->trueColor ? 3 : 1) * im->sx) % 4;
+	if (bpp < 8) {
+		padding = (im->sx + ppbyte - 1) / ppbyte % 4;
+	} else {
+		padding = ((int)(im->trueColor ? 3 : 1) * im->sx) % 4;
+	}
 	if (padding) {
 		padding = 4 - padding;
 	}
@@ -240,13 +257,37 @@ static int _gdImageBmpCtx(gdImagePtr im, gdIOCtxPtr out, int compression)
 		}
 
 		for (row = (im->sy - 1); row >= 0; row--) {
+			int byte = 0;
 			if (compression) {
 				memset (uncompressed_row, 0, gdImageSX(im));
 			}
 
 			for (xpos = 0; xpos < im->sx; xpos++) {
-				if (compression) {
+				if (compression && bpp < 8) {
+					byte = (byte << bpp) + gdImageGetPixel(im, xpos, row);
+					if (xpos % 2 == 1) {
+						*uncompressed_row++ = (unsigned char) byte;
+						byte = 0;
+					} else if (xpos + 1 == im->sx) {
+						/* imcomplete byte at end of row */
+						byte <<= bpp;
+						*uncompressed_row++ = (unsigned char) byte;
+						byte = 0;
+					}
+				} else if (compression) {
 					*uncompressed_row++ = (unsigned char)gdImageGetPixel(im, xpos, row);
+				} else if (bpp < 8) {
+					int next_chunk_in_byte = (xpos + 1) % ppbyte;
+					byte = (byte << bpp) + gdImageGetPixel(im, xpos, row);
+					if (next_chunk_in_byte == 0) {
+						gdPutC(byte, out);
+						byte = 0;
+					} else if (xpos + 1 == im->sx) {
+						/* imcomplete byte at end of row */
+						byte <<= bpp * (ppbyte - next_chunk_in_byte);
+						gdPutC(byte, out);
+						byte = 0;
+					}
 				} else {
 					gdPutC(gdImageGetPixel(im, xpos, row), out);
 				}
@@ -259,8 +300,10 @@ static int _gdImageBmpCtx(gdImagePtr im, gdIOCtxPtr out, int compression)
 				}
 			} else {
 				int compressed_size = 0;
+				int length = (gdImageSX(im) + ppbyte - 1) / ppbyte;
+				int nibble = gdImageSX(im) % ppbyte;
 				uncompressed_row = uncompressed_row_start;
-				if ((compressed_size = compress_row(uncompressed_row, gdImageSX(im))) < 0) {
+				if ((compressed_size = compress_row(uncompressed_row, length, ppbyte, nibble)) < 0) {
 					error = 1;
 					break;
 				}
@@ -333,7 +376,7 @@ static int _gdImageBmpCtx(gdImagePtr im, gdIOCtxPtr out, int compression)
 			if (gdPutBuf(copy_buffer , buffer_size, out_original) != buffer_size) {
 				gd_error("gd-bmp write error\n");
 				error = 1;
-			}
+		}
 		}
 		gdFree(copy_buffer);
 
@@ -360,7 +403,7 @@ cleanup:
 	return ret;
 }
 
-static int compress_row(unsigned char *row, int length)
+static int compress_row(unsigned char *row, int length, int ppbyte, int nibble)
 {
 	int rle_type = 0;
 	int compressed_length = 0;
@@ -392,9 +435,9 @@ static int compress_row(unsigned char *row, int length)
 		}
 
 		if (rle_type == BMP_RLE_TYPE_RLE) {
-			if (compressed_run >= 128 || memcmp(uncompressed_rowp, uncompressed_rowp - 1, 1) != 0) {
+			if (compressed_run >= 127 || memcmp(uncompressed_rowp, uncompressed_rowp - 1, 1) != 0) {
 				/* more than what we can store in a single run or run is over due to non match, force write */
-				rle_compression = build_rle_packet(row, rle_type, compressed_run, uncompressed_row);
+				rle_compression = build_rle_packet(row, rle_type, compressed_run, uncompressed_row, ppbyte, 0);
 				row += rle_compression;
 				compressed_length += rle_compression;
 				compressed_run = 0;
@@ -404,9 +447,9 @@ static int compress_row(unsigned char *row, int length)
 				uncompressed_rowp++;
 			}
 		} else {
-			if (compressed_run >= 128 || memcmp(uncompressed_rowp, uncompressed_rowp - 1, 1) == 0) {
+			if (compressed_run >= 127 || memcmp(uncompressed_rowp, uncompressed_rowp - 1, 1) == 0) {
 				/* more than what we can store in a single run or run is over due to match, force write */
-				rle_compression = build_rle_packet(row, rle_type, compressed_run, uncompressed_row);
+				rle_compression = build_rle_packet(row, rle_type, compressed_run, uncompressed_row, ppbyte, 0);
 				row += rle_compression;
 				compressed_length += rle_compression;
 				compressed_run = 0;
@@ -420,8 +463,9 @@ static int compress_row(unsigned char *row, int length)
 		}
 	}
 
+	/* the following condition is always true */
 	if (compressed_run) {
-		compressed_length += build_rle_packet(row, rle_type, compressed_run, uncompressed_row);
+		compressed_length += build_rle_packet(row, rle_type, compressed_run, uncompressed_row, ppbyte, nibble);
 	}
 
 	gdFree(uncompressed_start);
@@ -429,10 +473,10 @@ static int compress_row(unsigned char *row, int length)
 	return compressed_length;
 }
 
-static int build_rle_packet(unsigned char *row, int packet_type, int length, unsigned char *data)
+static int build_rle_packet(unsigned char *row, int packet_type, int length, unsigned char *data, int ppbyte, int nibble)
 {
 	int compressed_size = 0;
-	if (length < 1 || length > 128) {
+	if (length < 1 || length > 127) {
 		return 0;
 	}
 
@@ -441,7 +485,7 @@ static int build_rle_packet(unsigned char *row, int packet_type, int length, uns
 		int i = 0;
 		for (i = 0; i < length; i++) {
 			compressed_size += 2;
-			memset(row, 1, 1);
+			memset(row, ppbyte * 1 - (i + 1 == length ? nibble : 0), 1);
 			row++;
 
 			memcpy(row, data++, 1);
@@ -449,7 +493,7 @@ static int build_rle_packet(unsigned char *row, int packet_type, int length, uns
 		}
 	} else if (packet_type == BMP_RLE_TYPE_RLE) {
 		compressed_size = 2;
-		memset(row, length, 1);
+		memset(row, ppbyte * length - nibble, 1);
 		row++;
 
 		memcpy(row, data, 1);
@@ -459,7 +503,7 @@ static int build_rle_packet(unsigned char *row, int packet_type, int length, uns
 		memset(row, BMP_RLE_COMMAND, 1);
 		row++;
 
-		memset(row, length, 1);
+		memset(row, ppbyte * length - nibble, 1);
 		row++;
 
 		memcpy(row, data, length);

--- a/tests/bmp/CMakeLists.txt
+++ b/tests/bmp/CMakeLists.txt
@@ -4,6 +4,7 @@ LIST(APPEND TESTS_FILES
 	bug00450
 	bmp_im2im
 	bug00276
+	bmp_low_depth
 )
 
 ADD_GD_TESTS()

--- a/tests/bmp/Makemodule.am
+++ b/tests/bmp/Makemodule.am
@@ -3,7 +3,8 @@ libgd_test_programs += \
 	bmp/bug00275 \
 	bmp/bug00450 \
 	bmp/bmp_im2im \
-	bmp/bug00276
+	bmp/bug00276 \
+	bmp/bmp_low_depth
 
 EXTRA_DIST += \
 	bmp/bug00450.bmp \

--- a/tests/bmp/bmp_low_depth.c
+++ b/tests/bmp/bmp_low_depth.c
@@ -1,12 +1,22 @@
+/**
+ * Test transparent support for low-depth BMP images.
+ * 
+ * Images with only two colors are saved as 1bbp image without compression,
+ * but as 4bpp image if compression is requested.
+ * 
+ * Images with four to 15 colors are saved as 4bpp image, regardless whether
+ * compression is requested or not.
+ */
+
 #include "gd.h"
 #include "gdtest.h"
 
-int get_bpp(unsigned char *data)
+static int get_bpp(unsigned char *data)
 {
     return data[0x1d] << 8 | data[0x1c];
 }
 
-int get_comp(unsigned char *data)
+static int get_comp(unsigned char *data)
 {
     return data[0x21] << 24 | data[0x20] << 16 | data[0x1f] << 8 | data[0x1e];
 }

--- a/tests/bmp/bmp_low_depth.c
+++ b/tests/bmp/bmp_low_depth.c
@@ -1,0 +1,67 @@
+#include "gd.h"
+#include "gdtest.h"
+
+int get_bpp(unsigned char *data)
+{
+    return data[0x1d] << 8 | data[0x1c];
+}
+
+int get_comp(unsigned char *data)
+{
+    return data[0x21] << 24 | data[0x20] << 16 | data[0x1f] << 8 | data[0x1e];
+}
+
+int main()
+{
+    gdImagePtr im1, im2;
+    int fg, r, g, b;
+    int size;
+    unsigned char *data;
+
+    /* 2 color image */
+    im1 = gdImageCreate(99, 99); /* odd pixels per row! */
+    gdImageColorAllocate(im1, 0, 0, 0); /* background */
+    fg = gdImageColorAllocate(im1, 255, 255, 255);
+    gdImageRectangle(im1, 0, 0, 98, 98, fg); /* border to verify edge case */
+    gdImageEllipse(im1, 49, 49, 75, 75, fg);
+
+    data = gdImageBmpPtr(im1, &size, 0);
+    gdTestAssert(get_bpp(data) == 1);
+    gdTestAssert(get_comp(data) == 0);
+    im2 = gdImageCreateFromBmpPtr(size, data);
+    gdAssertImageEquals(im1, im2);
+
+    data = gdImageBmpPtr(im1, &size, 1);
+    gdTestAssert(get_bpp(data) == 4);
+    gdTestAssert(get_comp(data) == 2);
+    im2 = gdImageCreateFromBmpPtr(size, data);
+    gdAssertImageEquals(im1, im2);
+
+    /* 5 color image */
+    r = gdImageColorAllocate(im1, 255, 0, 0);
+    g = gdImageColorAllocate(im1, 0, 255, 0);
+    b = gdImageColorAllocate(im1, 0, 0, 255);
+    gdImageEllipse(im1, 17, 17, 28, 28, r);
+    gdImageEllipse(im1, 49, 17, 28, 28, r);
+    gdImageEllipse(im1, 81, 17, 28, 28, r);
+    gdImageEllipse(im1, 17, 49, 28, 28, g);
+    gdImageEllipse(im1, 49, 49, 28, 28, g);
+    gdImageEllipse(im1, 81, 49, 28, 28, g);
+    gdImageEllipse(im1, 17, 81, 28, 28, b);
+    gdImageEllipse(im1, 49, 81, 28, 28, b);
+    gdImageEllipse(im1, 81, 81, 28, 28, b);
+
+    data = gdImageBmpPtr(im1, &size, 0);
+    gdTestAssert(get_bpp(data) == 4);
+    gdTestAssert(get_comp(data) == 0);
+    im2 = gdImageCreateFromBmpPtr(size, data);
+    gdAssertImageEquals(im1, im2);
+
+    data = gdImageBmpPtr(im1, &size, 1);
+    gdTestAssert(get_bpp(data) == 4);
+    gdTestAssert(get_comp(data) == 2);
+    im2 = gdImageCreateFromBmpPtr(size, data);
+    gdAssertImageEquals(im1, im2);
+
+    return gdNumFailures();
+}


### PR DESCRIPTION
As is, we write palette images as 8bpp BMP images.  Besides that this is wasteful, some readers may not even be able to read 8bpp BMP images. Thus, we write palette images with at most two colors as 1bpp BMPs, unless compression is requested, because BMPs do not support compressed encoding of 1bpp images; we write palette images with at most 16 colors as 4bpp BMPs, and apply `BMP_BI_RLE4` compression if requested.

We piggy-back on the existing implementation for `BMP_BI_RLE8`; that keeps it simple, and although it might not yield the best compression, it ought to be good enough.

References:
<https://en.wikipedia.org/wiki/BMP_file_format>
<https://learn.microsoft.com/en-us/windows/win32/gdi/bitmap-compression>

Closes #911.

---

While implementing this, I've noticed that the RLE compression is not quite as good as it could be. While there is room for improvement, it might get pretty tricky, and it may not be worth spending further time on that, given that RLE encoding only yields somewhat good compression for images with few details, anyway.