### PR TITLE
Avoid undefined behavior

### DIFF
--- a/src/gd_nnquant.c
+++ b/src/gd_nnquant.c
@@ -309,7 +309,7 @@ static int contest(nn_quant *nnq, int al, int b, int g, int r)
 	double bestd,bestbiasd;
 	register int *p,*f, *n;
 
-	bestd = ~(((int) 1)<<31);
+	bestd = INT_MAX;
 	bestbiasd = bestd;
 	bestpos = 0;
 	bestbiaspos = bestpos;

--- a/src/gd_nnquant.c
+++ b/src/gd_nnquant.c
@@ -32,6 +32,7 @@
 #endif /* HAVE_CONFIG_H */
 
 #include <stdlib.h>
+#include <limits.h>
 #include <string.h>
 #include "gd.h"
 #include "gdhelpers.h"


### PR DESCRIPTION
Left-shifting the (32bit) signed int 1 by 31 exceeds the supported range, and is undefined behavior according to the C standards.  Instead of casting to int, which is implicit anyway, we could cast to unsigned int instead (or use `1U`), but directly using `INT_MAX` is more self- explaining.

PS: cf. <https://github.com/php/php-src/pull/17270/commits/86987c8c71a51ebbc09d97366c1c006c812092e6>