### PR TITLE
Fix heap corruption on Windows

### DIFF
--- a/src/gd_topal.c
+++ b/src/gd_topal.c
@@ -1534,6 +1534,14 @@ static void *malloc16(size_t size)
 	return _aligned_malloc(size, 16);
 #endif
 }
+static void free16(void *ptr)
+{
+#ifndef _WIN32
+	free(ptr);
+#else
+	_aligned_free(ptr);
+#endif
+}
 #endif
 
 /*
@@ -1614,7 +1622,7 @@ static int gdImageTrueColorToPaletteBody (gdImagePtr oim, int dither, int colors
 #ifdef HAVE_LIBIMAGEQUANT
 	if (oim->paletteQuantizationMethod == GD_QUANT_DEFAULT ||
 	        oim->paletteQuantizationMethod == GD_QUANT_LIQ) {
-		liq_attr *attr = liq_attr_create_with_allocator(malloc16, free);
+		liq_attr *attr = liq_attr_create_with_allocator(malloc16, free16);
 		liq_image *image;
 		liq_result *remap;
 		int remapped_ok = 0;


### PR DESCRIPTION
The recently merged #914 introduced a potential head corruption on Windows, since memory allocated with `_aligned_malloc()` needs to be freed with `_aligned_free()`.  Thus we introduce `free16()`.

---

Running the test suite against libgd built with libimagequant confirms the issue (three test cases fail with 0xc0000374).

Thanks to @thg2k for pointing out the problem!
