### PR TITLE
Set permissions: contents: read in all our workflows explicitly

### DIFF
--- a/.github/workflows/ci_gd3.yml
+++ b/.github/workflows/ci_gd3.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [ surface/surface ]
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/ci_gd3.yml
+++ b/.github/workflows/ci_gd3.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [ surface/surface ]
 
+permissions: read-all
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [master, GD-*]
 
-permissions: read-all
+permissions: 
+  contents: read
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/ci_macos.yml
+++ b/.github/workflows/ci_macos.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [master, GD-*]
 
+permissions: read-all
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: RELWITHDEBINFO

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [master, GD-*]
 
-permissions: read-all
+permissions: 
+  contents: read
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [master, GD-*]
 
+permissions: read-all
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: RELWITHDEBINFO

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -6,7 +6,8 @@ on:
   pull_request:
     branches: [master, GD-*]
 
-permissions: read-all
+permissions: 
+  contents: read
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/ci_windows.yml
+++ b/.github/workflows/ci_windows.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: [master, GD-*]
 
+permissions: read-all
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: RELWITHDEBINFO

--- a/.github/workflows/ci_windows_mingw.yml
+++ b/.github/workflows/ci_windows_mingw.yml
@@ -8,6 +8,8 @@ on:
 
   workflow_dispatch:
 
+permissions: read-all
+
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: RELWITHDEBINFO

--- a/.github/workflows/ci_windows_mingw.yml
+++ b/.github/workflows/ci_windows_mingw.yml
@@ -8,7 +8,8 @@ on:
 
   workflow_dispatch:
 
-permissions: read-all
+permissions: 
+  contents: read
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches: [master, GD-*]
 
+permissions: read-all
+
 jobs:
   coverity:
     strategy:

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -10,7 +10,8 @@ on:
   push:
     branches: [master, GD-*]
 
-permissions: read-all
+permissions: 
+  contents: read
 
 jobs:
   coverity:

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -9,6 +9,8 @@ on:
   pull_request:
     types: [opened]
 
+permissions: read-all
+
 jobs:
   shellcheck:
     name: Shellcheck

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -9,7 +9,8 @@ on:
   pull_request:
     types: [opened]
 
-permissions: read-all
+permissions: 
+  contents: read
 
 jobs:
   shellcheck:


### PR DESCRIPTION
GH now requires permissions to be set in workflows directly.
Set all of our CI jobs to read-only access to repository contents
since none of them need to make changes to any resources.