### PR TITLE
Close #921: Deprecate "native" MSVC and MSYS build support

### DIFF
--- a/windows/msys/README.MSYS.md
+++ b/windows/msys/README.MSYS.md
@@ -1,5 +1,9 @@
 # MSYS Fallback Makefile
 
+⚠️
+Due to lack of maintenance, building libgd this way is deprecated.
+Use CMake or autotools instead.
+
 This is a simple, straightforward Makefile for building LibGD with
 MinGW on MSYS (or possibly Cygwin).  It is here for anyone who doesn't
 want to deal with autotools or CMake on Windows or who can't get

--- a/windows/msys/README.MSYS.md
+++ b/windows/msys/README.MSYS.md
@@ -1,8 +1,8 @@
 # MSYS Fallback Makefile
 
-⚠️
-Due to lack of maintenance, building libgd this way is deprecated.
-Use CMake or autotools instead.
+> [!WARNING]
+> Due to lack of maintenance, building libgd this way is deprecated.
+> Use CMake or autotools instead.
 
 This is a simple, straightforward Makefile for building LibGD with
 MinGW on MSYS (or possibly Cygwin).  It is here for anyone who doesn't

--- a/windows/readme.md
+++ b/windows/readme.md
@@ -1,8 +1,8 @@
 # Building on Windows with Visual Studio 2015
 
-⚠️
-Due to lack of maintenance, building libgd this way is deprecated.
-Use CMake or autotools instead.
+> [!WARNING]
+> Due to lack of maintenance, building libgd this way is deprecated.
+> Use CMake or autotools instead.
 
 * Get the required dependencies from
   http://windows.php.net/downloads/php-sdk/deps/vc14/ and

--- a/windows/readme.md
+++ b/windows/readme.md
@@ -1,5 +1,9 @@
 # Building on Windows with Visual Studio 2015
 
+⚠️
+Due to lack of maintenance, building libgd this way is deprecated.
+Use CMake or autotools instead.
+
 * Get the required dependencies from
   http://windows.php.net/downloads/php-sdk/deps/vc14/ and
   http://windows.php.net/downloads/pecl/deps/, respectively. Choose the x86 or


### PR DESCRIPTION
PS: I'm also fine with GH flavored markdown, i.e.
````md
> [!WARNING]
> … deprecated …
````