### PR TITLE
Fix fix for #320

### DIFF
--- a/src/gd_interpolation.c
+++ b/src/gd_interpolation.c
@@ -1840,15 +1840,8 @@ BGD_DECLARE(gdImagePtr) gdImageRotateInterpolated(const gdImagePtr src, const fl
 	/* 0 && 90 degrees multiple rotation, 0 rotation simply clones the return image and convert it
 	   to truecolor, as we must return truecolor image. */
 	switch (angle_rounded) {
-		case    0: {
-			gdImagePtr dst = gdImageClone(src);
-
-			if (dst == NULL) {
-				return NULL;
-			}
-			if (src_cloned) gdImageDestroy(src_tc);
-			return dst;
-		}
+		case    0:
+			return src_cloned ? src_tc : gdImageClone(src);
 
 		case -27000:
 		case   9000:
@@ -1873,16 +1866,15 @@ BGD_DECLARE(gdImagePtr) gdImageRotateInterpolated(const gdImagePtr src, const fl
 
 	switch (src->interpolation_id) {
 		case GD_NEAREST_NEIGHBOUR: {
-			gdImagePtr res = gdImageRotateNearestNeighbour(src, angle, bgcolor);
+			gdImagePtr res = gdImageRotateNearestNeighbour(src_tc, angle, bgcolor);
 			if (src_cloned) gdImageDestroy(src_tc);
 			return res;
-			break;
 		}
 
 		case GD_BILINEAR_FIXED:
 		case GD_BICUBIC_FIXED:
 		default: {
-			gdImagePtr res = gdImageRotateGeneric(src, angle, bgcolor);
+			gdImagePtr res = gdImageRotateGeneric(src_tc, angle, bgcolor);
 			if (src_cloned) gdImageDestroy(src_tc);
 			return res;
 		}

--- a/tests/gdimagecopyrotated/bug00320.c
+++ b/tests/gdimagecopyrotated/bug00320.c
@@ -1,9 +1,11 @@
+/*
+ * Test that gdImageRotateInterpolated() never converts the src to palette.
+ */
+
 #include "gd.h"
 #include "gdtest.h"
 
-#define width 20
-
-int main()
+void rotate(int method, float angle)
 {
     gdImagePtr src, dst;
     int black;
@@ -12,11 +14,25 @@ int main()
     black = gdImageColorAllocate(src, 0, 0, 0);
 
     gdTestAssert(gdImageTrueColor(src) == 0);
-    dst = gdImageRotateInterpolated(src, 30.0, black);
+    gdImageSetInterpolationMethod(src, method);
+    dst = gdImageRotateInterpolated(src, angle, black);
     gdTestAssert(dst != NULL);
     gdTestAssert(gdImageTrueColor(src) == 0);
+    gdTestAssert(dst != src);
 
 	gdImageDestroy(src);
 	gdImageDestroy(dst);
-	return gdNumFailures();
+}
+
+int main()
+{
+    rotate(GD_DEFAULT, 30.0);
+    rotate(GD_NEAREST_NEIGHBOUR, 30.0);
+    rotate(GD_BILINEAR_FIXED, 30.0);
+    rotate(GD_BICUBIC_FIXED, 30.0);
+    rotate(GD_DEFAULT, 0.0);
+    rotate(GD_DEFAULT, 90.0);
+    rotate(GD_DEFAULT, 180.0);
+    rotate(GD_DEFAULT, 270.0);
+    return gdNumFailures();
 }


### PR DESCRIPTION
At least `gdImageRotateNearestNeighbour()` requires a truecolor image, so we should actually pass the truecolor clone.  To be safe regarding future changes, we also do this for `gdImageRotateGeneric()`.  And if rotation of zero degrees is requested, we return the already cloned image, instead of creating another clone.

We also extend the existing test case to cover all relevant code paths.

---

I've noticed a segfault while trying to port the [original fix](4a0d7d86f063b399a7549d20f24cc7f4ae059b0e) to PHP's bundled libgd.