### PR TITLE
Fix CMake build regarding C++ wrapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,10 +116,6 @@ else (USE_EXT_GD)
 	include(AC_HEADER_STDC)
 	include(CheckPrototypeExists)
 
-	if (ENABLE_CPP)
-		SET(ENABLE_CPP_API 1)
-	endif (ENABLE_CPP)
-
 	if (ENABLE_GD_FORMATS)
 		FIND_PACKAGE(ZLIB REQUIRED)
 	endif (ENABLE_GD_FORMATS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,7 +18,6 @@ SET (LIBGD_SRC_FILES
 	gd_io_dp.c
 	gd_io_file.c
 	gd_io_ss.c
-	gd_io_stream.cxx
 	gd_jpeg.c
 	gd_matrix.c
 	gd_nnquant.c
@@ -44,11 +43,17 @@ SET (LIBGD_SRC_FILES
 	gdfx.c
 	gdhelpers.c
 	gdkanji.c
-	gdpp.cxx
 	gdtables.c
 	gdxpm.c
 	wbmp.c
 )
+
+if(ENABLE_CPP)
+	LIST(APPEND LIBGD_SRC_FILES
+		gd_io_stream.cxx
+		gdpp.cxx
+	)
+endif(ENABLE_CPP)
 
 # Static library just for utility programs.
 SET (GD_PROGRAMS_LIB_SRC_FILES)

--- a/src/config.h.cmake
+++ b/src/config.h.cmake
@@ -3,9 +3,6 @@
 /* Define is you are building for Win32 API */
 #cmakedefine BGDWIN32
 
-/* Define is you are building for Win32 API */
-#cmakedefine ENABLE_CPP_API
-
 /* Whether to support gd image formats */
 #cmakedefine01 ENABLE_GD_FORMATS
 

--- a/src/gd_io_stream.cxx
+++ b/src/gd_io_stream.cxx
@@ -1,7 +1,6 @@
 #ifdef HAVE_CONFIG_H
 #	include "config.h"
 #endif
-#ifdef ENABLE_CPP_API
 /* *****************************************************************************
 ** Initial file written and documented by:
 ** Kevin Shepherd <kshepherd@php.net> December 2007
@@ -16,11 +15,6 @@
 	Note that half of the below methods are trivial stubs,
 	as an input stream has no need of output methods, and vice-versa.
 */
-#ifdef __cplusplus
-
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
 
 #include "gd_io_stream.h"
 
@@ -144,6 +138,3 @@ void ostreamIOCtx::FreeCtx(gdIOCtxPtr ctx)
 	{
 	delete (ostreamIOCtx * )ctx;
 	}
-
-#endif /* __cplusplus */
-#endif //ENABLE_CPP_API

--- a/src/gdpp.cxx
+++ b/src/gdpp.cxx
@@ -2,8 +2,6 @@
 #	include "config.h"
 #endif
 
-#ifdef ENABLE_CPP_API
-
 /* *****************************************************************************
 ** Initial file written and documented by:
 ** Kevin Shepherd <kshepherd@php.net> December 2007
@@ -17,7 +15,6 @@
 	Notably includes the methods which determine the image file
 	format of a file before reading it into memory.
 */
-#ifdef __cplusplus
 #include "gdpp.h"
 
 namespace GD
@@ -263,6 +260,3 @@ std::istream & operator>> (std::istream & in, GD::Image & img)
 	img.CreateFrom(in);
 	return in;
 	}
-
-#endif /* __cplusplus */
-#endif //ENABLE_CPP_API


### PR DESCRIPTION
We should only build the C++ wrapper, if it is actually enabled.  This makes the `ENABLE_CPP_API` macro superfluous, so we can remove it.

While we're at it, we also drop the meaningless `__cplusplus` condition and the duplicate inclusion of config.h.