### PR TITLE
Fix #937: ci.yml workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: [master, GD-*]
 
+permissions: 
+  contents: read
+
 jobs:
   ubuntu:
     uses: ./.github/workflows/ci_ubuntu.yml


### PR DESCRIPTION
We restrict the workflow to read permissions.