### PR TITLE
Make bug00320 more robust

### DIFF
--- a/tests/gdimagecopyrotated/bug00320.c
+++ b/tests/gdimagecopyrotated/bug00320.c
@@ -7,21 +7,34 @@
 
 void rotate(int method, float angle)
 {
-    gdImagePtr src, dst;
+    gdImagePtr src = NULL, dst = NULL;
     int black;
 
     src = gdImageCreate(10, 10);
+    if (!gdTestAssert(src != NULL)) {
+        goto out;
+    }
     black = gdImageColorAllocate(src, 0, 0, 0);
 
     gdTestAssert(gdImageTrueColor(src) == 0);
     gdImageSetInterpolationMethod(src, method);
     dst = gdImageRotateInterpolated(src, angle, black);
-    gdTestAssert(dst != NULL);
+    if (!gdTestAssert(dst != NULL)) {
+        goto out;
+    }
     gdTestAssert(gdImageTrueColor(src) == 0);
-    gdTestAssert(dst != src);
+    if (!gdTestAssert(dst != src)) {
+        // original image had been returned
+        dst = NULL;
+    }
 
-	gdImageDestroy(src);
-	gdImageDestroy(dst);
+out:
+    if (dst != NULL) {
+        gdImageDestroy(src);
+    }
+    if (src != NULL) {
+        gdImageDestroy(dst);
+    }
 }
 
 int main()

--- a/tests/gdimagecopyrotated/bug00320.c
+++ b/tests/gdimagecopyrotated/bug00320.c
@@ -5,7 +5,7 @@
 #include "gd.h"
 #include "gdtest.h"
 
-void rotate(int method, float angle)
+static void rotate(int method, float angle)
 {
     gdImagePtr src = NULL, dst = NULL;
     int black;


### PR DESCRIPTION
Failing `gdTestAssert()` will not abort, so we better ensure that even if the assertions are failing, the test has no memory issues.  This may also solve the issue reported by Coverity Scan[1].

[1] <https://github.com/libgd/libgd/pull/929#issuecomment-2581250179>