### PR TITLE
Drop useless and doubtful MSVC specific code

### DIFF
--- a/src/gd_interpolation.c
+++ b/src/gd_interpolation.c
@@ -72,11 +72,6 @@ TODO:
 #include "gdhelpers.h"
 #include "gd_intern.h"
 
-#ifdef _MSC_VER
-# pragma optimize("t", on)
-# include <intrin.h>
-#endif
-
 static gdImagePtr gdImageScaleBilinear(gdImagePtr im,
                                        const unsigned int new_width,
                                        const unsigned int new_height);


### PR DESCRIPTION
While we use some of intrinsic functions (like `cos()`), these are declared in math.h; we do not use any intrinsic function declared in intrin.h[1], though.  Interestingly, emmintrin.h had been included instead previously[2], what is about SSE2 instructions which we do not use in this file anyway.

We also remove the doubtful optimization pragma.  The kind of desired optimization should be chosen by the builder of the library, not by us. Furthermore, clang-cl does not even know about this pragma, and as such emits a warning.

[1] <https://learn.microsoft.com/en-us/cpp/intrinsics/intrinsics-available-on-all-architectures>
[2] <https://github.com/libgd/libgd/commit/98451864ceaae594a38b2fb316fc681ae4b88fa0>