### PR TITLE
Also run CI on Ubuntu 22.04

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -30,15 +30,15 @@ jobs:
               cxx: "clang"
             }
           - {
-              name: "Ubuntu 20.04 Intel GCC",
-              os: ubuntu-20.04,
+              name: "Ubuntu 22.04 Intel GCC",
+              os: ubuntu-22.04,
               cc: "gcc",
               cxx: "g++",
               cflags: "-msse2"
             }
           - {
-              name: "Ubuntu 20.04 Intel Clang",
-              os: ubuntu-20.04,
+              name: "Ubuntu 22.04 Intel Clang",
+              os: ubuntu-22.04,
               cc: "clang",
               cxx: "clang"
             }

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -17,15 +17,28 @@ jobs:
       matrix:
         config:
           - {
-              name: "Ubuntu Intel GCC",
+              name: "Ubuntu 24.04 Intel GCC",
               os: ubuntu-latest,
               cc: "gcc",
               cxx: "g++",
               cflags: "-msse2"
             }
           - {
-              name: "Ubuntu Intel Clang",
+              name: "Ubuntu 24.04 Intel Clang",
               os: ubuntu-latest,
+              cc: "clang",
+              cxx: "clang"
+            }
+          - {
+              name: "Ubuntu 20.04 Intel GCC",
+              os: ubuntu-20.04,
+              cc: "gcc",
+              cxx: "g++",
+              cflags: "-msse2"
+            }
+          - {
+              name: "Ubuntu 20.04 Intel Clang",
+              os: ubuntu-20.04,
               cc: "clang",
               cxx: "clang"
             }

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -36,12 +36,6 @@ jobs:
               cxx: "g++",
               cflags: "-msse2"
             }
-          - {
-              name: "Ubuntu 22.04 Intel Clang",
-              os: ubuntu-22.04,
-              cc: "clang",
-              cxx: "clang"
-            }
 
     name: ${{ matrix.config.name }}
     defaults:


### PR DESCRIPTION
This way we can test against some older library versions without needing to set this up ourselves.

---

Ubuntu 20.04 has EOL in May, and I guess it will be supported as GH hosted runner for a while longer. We could switch to Ubuntu 22.04 then.