### PR TITLE
Fix destruction of images in bug00320.c

### DIFF
--- a/tests/gdimagecopyrotated/bug00320.c
+++ b/tests/gdimagecopyrotated/bug00320.c
@@ -29,10 +29,10 @@ static void rotate(int method, float angle)
     }
 
 out:
-    if (dst != NULL) {
+    if (src != NULL) {
         gdImageDestroy(src);
     }
-    if (src != NULL) {
+    if (dst != NULL) {
         gdImageDestroy(dst);
     }
 }


### PR DESCRIPTION
We must only free the image, if it had been allocated.

Fixes CID 530896.