### PR TITLE
Attempt to fix CID 530895

### DIFF
--- a/src/gd_filter.c
+++ b/src/gd_filter.c
@@ -842,6 +842,8 @@ gaussian_coeffs(int radius, double sigmaArg) {
     double sum = 0;
     int x, n, count;
 
+    assert(radius >= 1);
+
     count = 2*radius + 1;
 
     result = gdMalloc(sizeof(double) * count);


### PR DESCRIPTION
If `gaussian_coeffs()` was called with a non-positve `radius`, bad things could happen, but we don't that; we add an `assert()` as safety net, and to enlighten static analyzers.

---

Frankly, I'm not sure what exactly is CoverityScan complaining about when they compain that `sum` might be zero, but this pre-condition `assert()` seems to be a good idea anyway.

We should probably also make sure that we don't call `gaussian_coeffs()` with a `radius > INT_MAX / 2 - 1` (or something like that; possibly using `overflow2()`).