### PR TITLE
Add CI job for Ubuntu 22.04 on ARM64

### DIFF
--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -41,7 +41,7 @@ jobs:
               os: ubuntu-22.04-arm,
               cc: "gcc",
               cxx: "g++",
-              cflags: "-msse2"
+              cflags: ""
             }
 
     name: ${{ matrix.config.name }}

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -36,6 +36,13 @@ jobs:
               cxx: "g++",
               cflags: "-msse2"
             }
+          - {
+              name: "Ubuntu 22.04 ARM64 GCC",
+              os: ubuntu-22.04-arm,
+              cc: "gcc",
+              cxx: "g++",
+              cflags: "-msse2"
+            }
 
     name: ${{ matrix.config.name }}
     defaults:

--- a/.github/workflows/ci_ubuntu.yml
+++ b/.github/workflows/ci_ubuntu.yml
@@ -41,7 +41,6 @@ jobs:
               os: ubuntu-22.04-arm,
               cc: "gcc",
               cxx: "g++",
-              cflags: ""
             }
 
     name: ${{ matrix.config.name }}


### PR DESCRIPTION
These are now in public beta, so we should try them.  We stick with Ubuntu 22.04 for now, due to known issues with newer dependency libraries on Ubuntu 24.04.

This also somewhat compensates the loss of our self-hosted Graviton runner[2].

[1] <https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/>
[2] <https://github.com/libgd/libgd/commit/4150a3174615397c38fc55310a1af35a7861054b>