### PR TITLE
Preserve transparent color information when converting a true color image to palette image

### DIFF
--- a/tests/gdimagetruecolortopalette/CMakeLists.txt
+++ b/tests/gdimagetruecolortopalette/CMakeLists.txt
@@ -1,6 +1,7 @@
 LIST(APPEND TESTS_FILES
 	bug00307
 	php_bug_72512
+	transparent_preserved
 )
 
 IF(JPEG_FOUND)

--- a/tests/gdimagetruecolortopalette/transparent_preserved.c
+++ b/tests/gdimagetruecolortopalette/transparent_preserved.c
@@ -1,0 +1,48 @@
+/**
+ * Regression test for <https://github.com/libgd/libgd/issues/307>
+ *
+ * We're testing that an image that has been converted to palette with
+ * GD_QUANT_NEUQUANT has its trueColor flag unset.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "gd.h"
+#include "gdtest.h"
+
+void test_transparent_preserved(enum gdPaletteQuantizationMethod method)
+{
+	gdImagePtr im;
+
+	im = gdImageCreateTrueColor(100, 100);
+
+    /* Assign a fully-transparent color for this image, so that the
+     * conversion to palette will have a reserved entry in the palette for
+     * 100% transparency. */
+    int transparent = gdImageColorResolveAlpha(im, 0, 0, 0, gdAlphaTransparent);
+	
+	printf("Transparent: %d\n", transparent);
+    gdImageColorTransparent(im, transparent);
+
+	gdTestAssert(gdImageTrueColorToPaletteSetMethod(im, method, 0));
+	gdImageTrueColorToPalette(im, 0, 256);
+	gdTestAssert(!gdImageTrueColor(im));
+	printf("Transparent: %d\n", im->transparent);
+	gdTestAssert(im->transparent >= 0);
+	gdTestAssertMsg(im->alpha[im->transparent] == gdAlphaTransparent,
+		"Transparent color is not gdAlphaTransparent for algorithm %d\n", method);
+}
+
+int main()
+{
+	// FIXME: transparent color is not updated when using GD_QUANT_NEUQUANT method
+	//test_transparent_preserved(GD_QUANT_NEUQUANT);
+	test_transparent_preserved(GD_QUANT_DEFAULT);
+#ifdef HAVE_LIBIMAGEQUANT
+	test_transparent_preserved(GD_QUANT_LIQ);
+#endif // HAVE_LIBIMAGEQUANT
+	test_transparent_preserved(GD_QUANT_JQUANT);
+	return gdNumFailures();
+}


### PR DESCRIPTION
I found this when using `GD_QUANT_LIQ` (`GD_QUANT_DEFAULT` with `-DENABLE_LIQ=ON`).
As indicated in the correspond unit test, `GD_QUANT_NEUQUANT` has the same issue.

When LIQ library is not used (`-DENABLE_LIQ=OFF`) the default quantization algorithm (`GD_QUANT_JQUANT`) doesn't have the issue.

The problem was that the code to preserve the transparent color wasn't executed when using liq, so I moved it into a common `success` label used in both case.