### PR TITLE
Initialize platform variables in gdft.c

### DIFF
--- a/src/gdft.c
+++ b/src/gdft.c
@@ -1137,7 +1137,7 @@ BGD_DECLARE(char *) gdImageStringFTEx (gdImagePtr im, int *brect, int fg, const 
 	gdCache_head_t *tc_cache;
 	/* Tuneable horizontal and vertical resolution in dots per inch */
 	int hdpi, vdpi, horiAdvance, vertAdvance, xshow_alloc = 0, xshow_pos = 0;
-	FT_Size platform_specific = NULL, platform_independent = NULL;
+	FT_Size platform_specific = NULL, platform_independent;
 
 	if (strex) {
 		if ((strex->flags & gdFTEX_LINESPACE) == gdFTEX_LINESPACE) {

--- a/src/gdft.c
+++ b/src/gdft.c
@@ -1137,7 +1137,7 @@ BGD_DECLARE(char *) gdImageStringFTEx (gdImagePtr im, int *brect, int fg, const 
 	gdCache_head_t *tc_cache;
 	/* Tuneable horizontal and vertical resolution in dots per inch */
 	int hdpi, vdpi, horiAdvance, vertAdvance, xshow_alloc = 0, xshow_pos = 0;
-	FT_Size platform_specific, platform_independent;
+	FT_Size platform_specific = NULL, platform_independent = NULL;
 
 	if (strex) {
 		if ((strex->flags & gdFTEX_LINESPACE) == gdFTEX_LINESPACE) {


### PR DESCRIPTION
Initializing these values explicitly to NULL ensures that they cannot be exploited at runtime.

Closes: #986
compile error C4703: potentially uninitialized local pointer variable 'platform_specific'

