### PR TITLE
Fix: -Wmaybe-uninitialized for image_type in gdImageCreateFromTiffCtx

### DIFF
--- a/src/gd_tiff.c
+++ b/src/gd_tiff.c
@@ -816,7 +816,7 @@ BGD_DECLARE(gdImagePtr) gdImageCreateFromTiffCtx(gdIOCtx *infile)
 	char	has_alpha, is_bw, is_gray;
 	char	force_rgba = FALSE;
 	char	save_transparent;
-	int		image_type;
+	int		image_type = 0;
 	int   ret;
 	float res_float;
 


### PR DESCRIPTION
```
src/gd_tiff.c: In function 'gdImageCreateFromTiffCtx':

src/gd_tiff.c:955:43: error: 'image_type' may be used uninitialized [-Werror=maybe-uninitialized]
  955 |                 (image_type == GD_PALETTE || image_type == GD_INDEXED || image_type == GD_GRAY)) {
      |                                           ^

src/gd_tiff.c:819:25: note: 'image_type' was declared here
  819 |         int             image_type;
      |                         ^~~~~~~~~~

'''