### PR TITLE
fix(bmp): validate image dimensions before BMP write

### DIFF
--- a/src/gd_bmp.c
+++ b/src/gd_bmp.c
@@ -366,7 +366,7 @@ static int _gdImageBmpCtx(gdImagePtr im, gdIOCtxPtr out, int bpp, int compressio
 	int ret = 1;
 	gdImagePtr write_im = im;
 
-	if (im == NULL || out == NULL) {
+	if (im == NULL || out == NULL || gdImageSX(im) <= 0 || gdImageSY(im) <= 0) {
 		return 1;
 	}
 

--- a/src/gd_bmp.c
+++ b/src/gd_bmp.c
@@ -366,7 +366,17 @@ static int _gdImageBmpCtx(gdImagePtr im, gdIOCtxPtr out, int bpp, int compressio
 	int ret = 1;
 	gdImagePtr write_im = im;
 
-	if (im == NULL || out == NULL || gdImageSX(im) <= 0 || gdImageSY(im) <= 0) {
+	if (im == NULL || out == NULL) {
+		return 1;
+	}
+
+	if (gdImageSX(im) <= 0 || gdImageSY(im) <= 0) {
+		gd_error("image dimensions must be greater than 0");
+		return 1;
+	}
+
+	if (overflow2(gdImageSX(im), gdImageSY(im))) {
+		gd_error("image dimensions are too large");
 		return 1;
 	}
 


### PR DESCRIPTION
## Summary
- Add validation for non-positive image dimensions (`sx <= 0 || sy <= 0`) in `_gdImageBmpCtx` to prevent negative int values from being implicitly cast to huge `size_t` values in `gdMalloc`/`memcpy` calls within `compress_row`

Fixes #1007