### PR TITLE
fix(test): skip fontconfig/basic when no fonts are installed

### DIFF
--- a/tests/fontconfig/CMakeLists.txt
+++ b/tests/fontconfig/CMakeLists.txt
@@ -1,8 +1,20 @@
 if(FONTCONFIG_FOUND)
 IF(FREETYPE_FOUND)
-LIST(APPEND TESTS_FILES
-    basic
-)
+	# Skip fontconfig tests when no fonts are installed (e.g. minimal containers)
+	execute_process(
+		COMMAND fc-list
+		OUTPUT_VARIABLE FC_LIST_OUTPUT
+		ERROR_QUIET
+		OUTPUT_STRIP_TRAILING_WHITESPACE
+	)
+
+	if(NOT FC_LIST_OUTPUT STREQUAL "")
+		LIST(APPEND TESTS_FILES
+			basic
+		)
+	else()
+		message(STATUS "Fontconfig has no fonts available - skipping fontconfig/basic test")
+	endif()
 ENDIF(FREETYPE_FOUND)
 ENDIF(FONTCONFIG_FOUND)
 

--- a/tests/fontconfig/basic.c
+++ b/tests/fontconfig/basic.c
@@ -4,10 +4,6 @@
  * Without actually using fontconfig, passing an empty fontlist to
  * gdImageStringFT() would return an error ("Could not find/open font").
  * We're checking that it returns NULL.
- *
- * If fontconfig is compiled in but no fonts are installed (e.g., in a
- * minimal container), the test is skipped since this is an environment
- * issue rather than a code defect.
  */
 
 #include "gd.h"
@@ -25,14 +21,6 @@ int main() {
 
 	gdTestAssert(gdFTUseFontConfig(1));
 	error = gdImageStringFT(im, NULL, black, "", 14.0, 0.0, 10, 20, "foo");
-
-	if (error) {
-		/* fontconfig compiled but no fonts available in this environment;
-		   not a code defect, so skip */
-		gdImageDestroy(im);
-		gdFontCacheShutdown();
-		return 0;
-	}
 	gdTestAssertMsg(error == NULL, "%s", error);
 
 	gdImageDestroy(im);

--- a/tests/fontconfig/basic.c
+++ b/tests/fontconfig/basic.c
@@ -4,6 +4,10 @@
  * Without actually using fontconfig, passing an empty fontlist to
  * gdImageStringFT() would return an error ("Could not find/open font").
  * We're checking that it returns NULL.
+ *
+ * If fontconfig is compiled in but no fonts are installed (e.g., in a
+ * minimal container), the test is skipped since this is an environment
+ * issue rather than a code defect.
  */
 
 #include "gd.h"
@@ -21,6 +25,14 @@ int main() {
 
 	gdTestAssert(gdFTUseFontConfig(1));
 	error = gdImageStringFT(im, NULL, black, "", 14.0, 0.0, 10, 20, "foo");
+
+	if (error) {
+		/* fontconfig compiled but no fonts available in this environment;
+		   not a code defect, so skip */
+		gdImageDestroy(im);
+		gdFontCacheShutdown();
+		return 0;
+	}
 	gdTestAssertMsg(error == NULL, "%s", error);
 
 	gdImageDestroy(im);


### PR DESCRIPTION
## Summary
- Move the skip logic from C code to CMake build system
- When fontconfig is compiled but no fonts are installed (e.g. minimal containers), the test is not registered at all via `execute_process(fc-list)` check
- Revert `basic.c` to its original strict form (no early return)

## Changes
| File | Change |
|------|--------|
| `tests/fontconfig/CMakeLists.txt` | Add `fc-list` detection; only register the `basic` test when fonts are available |
| `tests/fontconfig/basic.c` | Reverted to master (removed early return that masked all errors) |

## Why this approach
The previous implementation returned 0 for *any* `gdImageStringFT` error, which would hide actual code defects. Per reviewer feedback, the detection is now done at the CMake level — if no fonts are installed, the test is simply not registered, keeping the test strict for environments that do have fonts.

## Test Plan
- [ ] All tests pass with fontconfig + freetype enabled (fonts available)
- [ ] `fontconfig/basic` test does not appear in ctest list when `fc-list` returns empty
- [ ] Build system prints `"Fontconfig has no fonts available - skipping fontconfig/basic test"` status message in minimal containers

Fixes #367