### PR TITLE
gd_tiff: fix integer overflow in createFromTiffRgba() (GHSA-xxr2-j7hw-3698)

### DIFF
--- a/src/gd_tiff.c
+++ b/src/gd_tiff.c
@@ -1065,6 +1065,10 @@ static int createFromTiffRgba(TIFF *tif, gdImagePtr im)
     uint32_t rgba;
     int success;
 
+    if (overflow2(width, height) || overflow2(width * height, sizeof(uint32_t))) {
+        return GD_FAILURE;
+    }
+
     buffer = (uint32_t *)gdCalloc(sizeof(uint32_t), width * height);
     if (!buffer) {
         return GD_FAILURE;


### PR DESCRIPTION
Fixes the heap buffer overflow reported in GHSA-xxr2-j7hw-3698.

createFromTiffRgba() allocated `4 * width * height` without an overflow
check. A crafted TIFF with width*height = 2^30 wraps the size_t
multiplication to a near-zero allocation on libcs whose calloc() does not
detect multiplicative overflow (musl, bionic, uclibc), and
TIFFReadRGBAImage() then writes ~4 GiB into it — a heap buffer overflow.

This adds an overflow2() guard consistent with the existing checks in
gd_tiff.c.