### PR TITLE
fix(gdft): detect backslash path separators in font_path()

### DIFF
--- a/src/gdft.c
+++ b/src/gdft.c
@@ -1608,7 +1608,7 @@ static char *font_path(char **fontpath, char *name_list)
             return "could not alloc full path of font";
         }
         /* if name is an absolute or relative pathname then test directly */
-        if (strchr(name, '/') ||
+        if (strchr(name, '/') || strchr(name, '\\') ||
             (name[0] != 0 && name[1] == ':' && (name[2] == '/' || name[2] == '\\'))) {
             sprintf(fullname, "%s", name);
             if (access(fullname, R_OK) == 0) {


### PR DESCRIPTION
## Summary
- `font_path()` checked for forward slashes and Windows drive letters to decide whether a font name is an absolute/relative pathname, but did not detect backslash (`\`) separators.
- This caused UNC paths (`\\server\share\font`) and relative Windows paths (e.g. `.\font.ttf`) to be searched in `GDFONTPATH` instead of being tested directly with `access()`, unlike their forward-slash equivalents.
- Add `strchr(name, '\\')` alongside the existing `strchr(name, '/')` check. If the direct `access()` fails, behavior still falls through to the `GDFONTPATH` search loop, so this is safe.

## Verification
- Builds cleanly with `-DENABLE_FREETYPE=1`.
- Test suite: 128/129 pass. The single failure (`test_gdimageaffine_interpolation`) is pre-existing and caused by PNG support being disabled in the build environment, unrelated to this change.

Fixes #413, #952
