### PR TITLE
fix font_path() to detect backslash path separators

### DIFF
--- a/src/gdft.c
+++ b/src/gdft.c
@@ -1608,7 +1608,7 @@ static char *font_path(char **fontpath, char *name_list)
             return "could not alloc full path of font";
         }
         /* if name is an absolute or relative pathname then test directly */
-        if (strchr(name, '/') ||
+        if (strchr(name, '/') || strchr(name, '\\') ||
             (name[0] != 0 && name[1] == ':' && (name[2] == '/' || name[2] == '\\'))) {
             sprintf(fullname, "%s", name);
             if (access(fullname, R_OK) == 0) {


### PR DESCRIPTION
`font_path()` checks whether a font name is an absolute or relative pathname so it can be tested directly with `access()`. It detected forward slashes and Windows drive letters, but not backslash separators.

This caused UNC paths (`\\server\share\font`) and relative Windows paths (e.g. `.\font.ttf`) to fall through to the `GDFONTPATH` search loop, unlike their forward-slash equivalents.

The fix adds `strchr(name, '\\')` alongside the existing `strchr(name, '/')` check. If the direct `access()` fails, it still falls through to the search loop, so existing behavior is preserved.

Builds cleanly with `-DENABLE_FREETYPE=1`; test suite 128/129 pass (the single failure, `gdimageaffine_interpolation`, is pre-existing and due to PNG being disabled in the build environment, unrelated to this change).

Fixes #413, #952
